### PR TITLE
Fish-6989:map jsonp 2.1 to advisor tool

### DIFF
--- a/src/main/resources/config/jakarta10/advisorFix/jakarta-jsonp-fix-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorFix/jakarta-jsonp-fix-messages.properties
@@ -1,0 +1,40 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-jsonp-method-change-type-bounds=This issue won't affect your application. \n \
+The recommendation is to take care of the generic version.

--- a/src/main/resources/config/jakarta10/advisorMessages/jakarta-jsonp-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorMessages/jakarta-jsonp-messages.properties
@@ -1,0 +1,42 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-jsonp-method-change-type-bounds=Jakarta JSON Processing 2.1 \
+\n method Json.createObjectBuilder with Map parameter was changed from \
+\n public static JsonObjectBuilder createObjectBuilder(Map<String, Object> map) { \
+\n to \n public static JsonObjectBuilder createObjectBuilder(Map<String, ?> map) {

--- a/src/main/resources/config/jakarta10/mappedPatterns/jakarta-jsonp.properties
+++ b/src/main/resources/config/jakarta10/mappedPatterns/jakarta-jsonp.properties
@@ -1,0 +1,39 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-jsonp-method-change-type-bounds=json.Json#createObjectBuilder(Map)


### PR DESCRIPTION
mapping jsonp 2.1 to advisor tool:

result of test:
`
[WARNING] Line of code: 19 | Expression: Json.createObjectBuilder(m)
Source file: JsonPTest.java
Jakarta JSON Processing 2.1
 method Json.createObjectBuilder with Map parameter was changed from
 public static JsonObjectBuilder createObjectBuilder(Map<String, Object> map) {
 to
 public static JsonObjectBuilder createObjectBuilder(Map<String, ?> map) {
This issue won't affect your application.
 The recommendation is to take care of the generic version.
`