### PR TITLE
Fish-6990: map jakarta messaging 3.1 to advisor tool

### DIFF
--- a/src/main/resources/config/jakarta10/advisorFix/jakarta-messaging-fix-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorFix/jakarta-messaging-fix-messages.properties
@@ -1,0 +1,42 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-messaging-method-change-adding-repeatable-connection-factory=This issue won't affect your application. \n \
+Now you can use @JMSConnectionFactoryDefinition multiple times on the same component.
+jakarta-messaging-method-change-adding-repeatable-destination-definition=This issue won't affect your application. \n \
+Now you can use @JMSDestinationDefinition multiple times on the same component.

--- a/src/main/resources/config/jakarta10/advisorMessages/jakarta-messaging-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorMessages/jakarta-messaging-messages.properties
@@ -1,0 +1,42 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-messaging-method-change-adding-repeatable-connection-factory=Jakarta Messaging 3.1 \
+\n Annotation @JMSConnectionFactoryDefinition changed to be repeatable.
+jakarta-messaging-method-change-adding-repeatable-destination-definition=Jakarta Messaging 3.1 \
+\n Annotation @JMSDestinationDefinition changed to be repeatable.

--- a/src/main/resources/config/jakarta10/mappedPatterns/jakarta-messaging.properties
+++ b/src/main/resources/config/jakarta10/mappedPatterns/jakarta-messaging.properties
@@ -1,0 +1,40 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-messaging-method-change-adding-repeatable-connection-factory=jms.JMSConnectionFactoryDefinition@name
+jakarta-messaging-method-change-adding-repeatable-destination-definition=jms.JMSDestinationDefinition@name


### PR DESCRIPTION
Mapping jakarta messaging 3.1 to advisor tool

Result of tests:
`
[WARNING] Line of code: 8 | Expression: @JMSConnectionFactoryDefinition(name = "")
Source file: JMSBeanTest.java
Jakarta Messaging 3.1
 Annotation @JMSConnectionFactoryDefinition changed to be repeatable.
This issue won't affect your application.
 Now you can use @JMSConnectionFactoryDefinition multiple times on the same component.

[WARNING] Line of code: 7 | Expression: @JMSDestinationDefinition(name = "ddd", interfaceName = "")
Source file: JMSDestinationTest.java
Jakarta Messaging 3.1
 Annotation @JMSDestinationDefinition changed to be repeatable.
This issue won't affect your application.
 Now you can use @JMSDestinationDefinition multiple times on the same component.
`