### PR TITLE
FISH-6992: Mapping Jakarta Persistence 3.1 to advisor tool

### DIFF
--- a/src/main/resources/config/jakarta10/advisorFix/jakarta-persistence-fix-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorFix/jakarta-persistence-fix-messages.properties
@@ -1,0 +1,44 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-persistence-method-change-adding-autocloseable-entity-manager-factory=This issue won't affect your application. \n \
+Now you can use try-with-resources when calling EntityManagerFactory to improve resources usage.
+jakarta-persistence-method-change-adding-autocloseable-entity-manager=This issue won't affect your application. \n \
+Now you can use try-with-resources when calling EntityManager to improve resources usage.
+jakarta-persistence-method-change-adding-uuid-type-generation-type=This issue won't affect your application. \n \
+Now you can use a new type for generation of ID's based on RFC 4122 Universally Unique Identifier.

--- a/src/main/resources/config/jakarta10/advisorMessages/jakarta-persistence-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorMessages/jakarta-persistence-messages.properties
@@ -1,0 +1,44 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-persistence-method-change-adding-autocloseable-entity-manager-factory=Jakarta Persistence 3.1 \
+  \n EntityManagerFactory interface now implements AutoCloseable.
+jakarta-persistence-method-change-adding-autocloseable-entity-manager=Jakarta Persistence 3.1 \
+  \n EntityManager interface now implements AutoCloseable.
+jakarta-persistence-method-change-adding-uuid-type-generation-type=Jakarta Persistence 3.1 \
+  \n new generation type was added of type UUID.

--- a/src/main/resources/config/jakarta10/mappedPatterns/jakarta-persistence.properties
+++ b/src/main/resources/config/jakarta10/mappedPatterns/jakarta-persistence.properties
@@ -1,0 +1,41 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-persistence-method-change-adding-autocloseable-entity-manager-factory=persistence.EntityManagerFactory
+jakarta-persistence-method-change-adding-autocloseable-entity-manager=persistence.EntityManager
+jakarta-persistence-method-change-adding-uuid-type-generation-type=persistence.GenerationType


### PR DESCRIPTION
Mapping jakarta persistence 3.1 to advisor tool:

Result of tests:
`
[WARNING] Line of code: 3 | Expression: jakarta.persistence.EntityManager
Source file: BeanUseEntity.java
Jakarta Persistence 3.1
 EntityManager interface now implements AutoCloseable.
This issue won't affect your application.
 Now you can use try-with-resources when calling EntityManager to improve resources usage.

[WARNING] Line of code: 4 | Expression: jakarta.persistence.EntityManagerFactory
Source file: BeanUseEntity.java
Jakarta Persistence 3.1
 EntityManagerFactory interface now implements AutoCloseable.
This issue won't affect your application.
 Now you can use try-with-resources when calling EntityManagerFactory to improve resources usage.

[WARNING] Line of code: 5 | Expression: jakarta.persistence.GenerationType
Source file: JPABeanTest.java
Jakarta Persistence 3.1
 new generation type was added of type UUID.
This issue won't affect your application.
 Now you can use a new type for generation of ID's based on RFC 4122 Universally Unique Identifier.
`