### PR TITLE
FISH-6993: Mapping Jakarta RESTful Web services 3.1 to advisor tool

### DIFF
--- a/src/main/java/fish/payara/advisor/AdvisorAnnotationWithProperty.java
+++ b/src/main/java/fish/payara/advisor/AdvisorAnnotationWithProperty.java
@@ -41,7 +41,9 @@ package fish.payara.advisor;
 
 import com.github.javaparser.Position;
 import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import java.io.File;
@@ -86,6 +88,32 @@ public class AdvisorAnnotationWithProperty implements AdvisorInterface {
                     collector.add(advisorBean);
             }
             
+        }
+
+        @Override
+        public void visit(SingleMemberAnnotationExpr singleMemberAnnotationExpr, List<AdvisorBean> collector) {
+            super.visit(singleMemberAnnotationExpr, collector);
+            Optional<Position> p = singleMemberAnnotationExpr.getBegin();
+            String annotationName = valuePattern.substring(valuePattern.lastIndexOf(".") + 1, valuePattern.length());
+            if(singleMemberAnnotationExpr.toString().contains(annotationName) && singleMemberAnnotationExpr.toString().contains(secondPattern)) {
+                AdvisorBean advisorBean = new AdvisorBean.AdvisorBeanBuilder(keyPattern, annotationName +"@"+secondPattern)
+                        .setLine((p.map(position -> "" + position.line).orElse("")))
+                        .setAnnotationDeclaration(singleMemberAnnotationExpr.toString()).build();
+                collector.add(advisorBean);
+            }
+        }
+
+        @Override
+        public void visit(MarkerAnnotationExpr markerAnnotationExpr, List<AdvisorBean> collector) {
+            super.visit(markerAnnotationExpr, collector);
+            Optional<Position> p = markerAnnotationExpr.getBegin();
+            String annotationName = valuePattern.substring(valuePattern.lastIndexOf(".") + 1, valuePattern.length());
+            if (markerAnnotationExpr.toString().contains(annotationName) && markerAnnotationExpr.toString().contains(secondPattern)) {
+                AdvisorBean advisorBean = new AdvisorBean.AdvisorBeanBuilder(keyPattern, annotationName + "@" + secondPattern)
+                        .setLine((p.map(position -> "" + position.line).orElse("")))
+                        .setAnnotationDeclaration(markerAnnotationExpr.toString()).build();
+                collector.add(advisorBean);
+            }
         }
     }
 

--- a/src/main/java/fish/payara/advisor/AdvisorConstructorCall.java
+++ b/src/main/java/fish/payara/advisor/AdvisorConstructorCall.java
@@ -40,23 +40,18 @@
 package fish.payara.advisor;
 
 import com.github.javaparser.Position;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.expr.ClassExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
-
 import java.util.List;
 import java.util.Optional;
 
-public class AdvisorMethodCall implements AdvisorInterface {
+public class AdvisorConstructorCall implements AdvisorInterface {
+
 
     @Override
     public VoidVisitor<List<AdvisorBean>> createVoidVisitor(String keyPattern, String valuePattern, String... params) {
-        return new MethodCallCollector(keyPattern, valuePattern, params);
+        return new AdvisorConstructorCall.ConstructorCallCollector(keyPattern, valuePattern);
     }
 
     @Override
@@ -64,65 +59,27 @@ public class AdvisorMethodCall implements AdvisorInterface {
         return null;
     }
 
-
-    private static class MethodCallCollector extends VoidVisitorAdapter<List<AdvisorBean>> {
-
+    private static class ConstructorCallCollector extends VoidVisitorAdapter<List<AdvisorBean>> {
         private final String keyPattern;
         private final String valuePattern;
-        private final String[] params;
-
-        public MethodCallCollector(String keyPattern, String valuePattern, String... params) {
+        public ConstructorCallCollector(String keyPattern, String valuePattern) {
             this.keyPattern = keyPattern;
             this.valuePattern = valuePattern;
-            this.params = params;
-        }
-
-        public void visit(MethodCallExpr methodCall, List<AdvisorBean> collector) {
-            super.visit(methodCall, collector);
-            Optional<Position> p = methodCall.getBegin();
-            if (methodCall.toString().contains(valuePattern)) {
-                AdvisorBean advisorMethodBean = new AdvisorBean.
-                        AdvisorBeanBuilder(keyPattern, valuePattern).
-                        setLine((p.map(position -> "" + position.line).orElse(""))).
-                        setMethodDeclaration(methodCall.asMethodCallExpr().toString()).build();
-                collector.add(advisorMethodBean);
-            } else if (valuePattern.contains("(") && valuePattern.contains(")") &&
-                    methodCall.toString().contains(valuePattern.substring(0, valuePattern.indexOf('('))) &&
-                    isSameArgumentTypes(params, methodCall.getArguments())) {
-                AdvisorBean advisorMethodBean = new AdvisorBean.
-                        AdvisorBeanBuilder(keyPattern, valuePattern).
-                        setLine((p.map(position -> "" + position.line).orElse(""))).
-                        setMethodDeclaration(methodCall.asMethodCallExpr().toString()).build();
-                collector.add(advisorMethodBean);
-            }
         }
 
         @Override
-        public void visit(ClassExpr classExpr, List<AdvisorBean> collector) {
-            super.visit(classExpr, collector);
-            Optional<Position> p = classExpr.getBegin();
-            if(classExpr.isClassExpr() && classExpr.toString().contains(valuePattern)) {
-                AdvisorBean advisorMethodBean = new AdvisorBean.AdvisorBeanBuilder(keyPattern, valuePattern).
+        public void visit(ObjectCreationExpr objectCreationExpr, List<AdvisorBean> advisorBeans) {
+            super.visit(objectCreationExpr, advisorBeans);
+            Optional<Position> p = objectCreationExpr.getBegin();
+            if(objectCreationExpr.isObjectCreationExpr() &&
+                    objectCreationExpr.toString().contains(valuePattern)) {
+                AdvisorBean advisorMethodBean = new AdvisorBean.
+                        AdvisorBeanBuilder(keyPattern, valuePattern).
                         setLine((p.map(position -> "" + position.line).orElse(""))).
-                        setMethodDeclaration(classExpr.toString()).build();
-                collector.add(advisorMethodBean);
+                        setMethodDeclaration(objectCreationExpr.toString()).build();
+                advisorBeans.add(advisorMethodBean);
             }
-        }
-
-        private boolean isSameArgumentTypes(String[] params, NodeList<Expression> nodeList) {
-            if (nodeList.size() != params.length) {
-                return false;
-            }
-            for (int i = 0; i < nodeList.size(); i++) {
-                Expression argument = nodeList.get(i);
-                if (argument instanceof ObjectCreationExpr) {
-                    ClassOrInterfaceType type = ((ObjectCreationExpr) argument).getType();
-                    if (!type.getName().asString().equals(params[i])) {
-                        return false;
-                    }
-                }
-            }
-            return true;
         }
     }
+    
 }

--- a/src/main/java/fish/payara/advisor/AdvisorToolMojo.java
+++ b/src/main/java/fish/payara/advisor/AdvisorToolMojo.java
@@ -40,12 +40,6 @@
 package fish.payara.advisor;
 
 import fish.payara.advisor.config.files.BeansXml;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -215,27 +209,32 @@ public class AdvisorToolMojo extends AbstractMojo {
         AdvisorBean advisorBean = null;
         AdvisorClassImport acimp = new AdvisorClassImport();
         try {
-            advisorBean = acimp.parseFile((String) key, importNameSpace, sourceFile);
+            advisorBean = acimp.parseFile(key, importNameSpace, sourceFile);
             //check if method call
             if(advisorBean != null) {
                 AdvisorMethodCall amc = new AdvisorMethodCall();
                 if (methodCall.contains("(") && methodCall.contains(")")) {
                     String args = methodCall.substring(methodCall.indexOf('(') + 1, methodCall.indexOf(')'));
                     if (args.indexOf(',') > -1) {
-                        advisorBean = amc.parseFile((String) key, methodCall, sourceFile, args.split(","));
+                        advisorBean = amc.parseFile(key, methodCall, sourceFile, args.split(","));
                     } else {
-                        advisorBean = amc.parseFile((String) key, methodCall, sourceFile, args);
+                        advisorBean = amc.parseFile(key, methodCall, sourceFile, args);
                     }
+                } else if(methodCall.contains("constructor")){
+                    AdvisorConstructorCall acc = new AdvisorConstructorCall();
+                    String constructorClass = importNameSpace.substring(importNameSpace.lastIndexOf(".") + 1, 
+                            importNameSpace.length());
+                    advisorBean = acc.parseFile(key, constructorClass, sourceFile);
                 } else {
-                    advisorBean = amc.parseFile((String) key, methodCall, sourceFile);
+                    advisorBean = amc.parseFile(key, methodCall, sourceFile);
                 }
-                //advisorBean = amc.parseFile((String) key, methodCall, sourceFile);
+                
                 if (advisorBean != null) {
                     advisorsList.add(advisorBean);
                 } else {
                     //check if method declaration
                     AdvisorMethodDeclaration amd = new AdvisorMethodDeclaration();
-                    advisorBean = amd.parseFile((String)key, methodCall, sourceFile);
+                    advisorBean = amd.parseFile(key, methodCall, sourceFile);
                     if(advisorBean != null) {
                         advisorsList.add(advisorBean);
                     }
@@ -253,11 +252,11 @@ public class AdvisorToolMojo extends AbstractMojo {
         AdvisorBean advisorBean = null;
         AdvisorClassImport acimp = new AdvisorClassImport();
         try {
-            advisorBean = acimp.parseFile((String) key, importAnnotationNameSpace, sourceFile);
+            advisorBean = acimp.parseFile(key, importAnnotationNameSpace, sourceFile);
             //check if annotation with property
             if (advisorBean != null) {
                 AdvisorAnnotationWithProperty aacwp = new AdvisorAnnotationWithProperty();
-                advisorBean = aacwp.parseFile((String) key, importAnnotationNameSpace, annotationPropertyDeclaration, sourceFile);
+                advisorBean = aacwp.parseFile(key, importAnnotationNameSpace, annotationPropertyDeclaration, sourceFile);
                 if(advisorBean != null) {
                     advisorsList.add(advisorBean);
                 }

--- a/src/main/resources/config/jakarta10/advisorFix/jakarta-restful-ws-fix-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorFix/jakarta-restful-ws-fix-messages.properties
@@ -1,0 +1,52 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-restful-ws-method-change-must-favor-jsonb=This issue won't affect your application. \n \
+  Whenever you use ContextResolver for JSON-B entities, the recommendation is to use Jsonb instances.
+jakarta-restful-ws-method-change-produces-multipart=This issue won't affect your application. \n
+jakarta-restful-ws-method-change-consumes-multipart=This issue won't affect your application. \n
+jakarta-restful-ws-method-change-context-deprecated=This issue won't affect your application. \n \
+The advice is to use CDI injection instead of @Context.
+jakarta-restful-ws-method-change-jaxblink-deprecated=This issue won't affect your application. \n \
+The advice is to stop using the inner class JaxbLink.
+jakarta-restful-ws-method-change-jaxbadapter-deprecated=This issue won't affect your application. \n \
+The advice is to stop using the inner class JaxbAdapter.
+jakarta-restful-ws-method-change-cookie-constructor-deprecated=This issue won't affect your application. \n \
+The advice is to change for Cookie.Builder class.
+jakarta-restful-ws-method-change-newcookie-constructor-deprecated=This issue won't affect your application. \n \
+The advixe is to change for NewCookie.Builder class.

--- a/src/main/resources/config/jakarta10/advisorMessages/jakarta-restful-ws-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorMessages/jakarta-restful-ws-messages.properties
@@ -1,0 +1,57 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-restful-ws-method-change-must-favor-jsonb=Jakarta RESTful 3.1 \
+\n JSON-B entity providers must favor Jsonb instances provided by ContextResolver<Jsonb>
+jakarta-restful-ws-method-change-produces-multipart=Jakarta RESTful 3.1 \
+\n Now you can process MULTIPART_FORM_DATA with List<EntityPart> as a parameter on the method or by using @FormParam for each of the parts \
+\n indicating the name of the param for the following types: String, InputString or EntityPart
+jakarta-restful-ws-method-change-consumes-multipart=Jakarta RESTful 3.1 \
+\n Now you can process MULTIPART_FORM_DATA with List<EntityPart> as a parameter on the method or by using @FormParam for each of the parts \
+\n indicating the name of the param for the following types: String, InputString or EntityPart
+jakarta-restful-ws-method-change-context-deprecated=Jakarta RESTful 3.1 \
+\n The @Context annotation is deprecated and future versions of Jakarta RESTful \
+services will no longer support it.
+jakarta-restful-ws-method-change-jaxblink-deprecated=Jakarta RESTful 3.1 \
+\n The JaxbLink class was deprecated and future version of Jakarta RESTful services will no longer support it.
+jakarta-restful-ws-method-change-jaxbadapter-deprecated=Jakarta RESTful 3.1 \
+\n The JaxbAdapter class was deprecated and future version of Jakarta RESTful services will no longer support it.
+jakarta-restful-ws-method-change-cookie-constructor-deprecated=Jakarta RESTful 3.1 \
+ \n Constructors for Cookie class were deprecated.
+jakarta-restful-ws-method-change-newcookie-constructor-deprecated=Jakarta RESTful 3.1 \
+ \n Constructors for NewCookie class were deprecated.

--- a/src/main/resources/config/jakarta10/mappedPatterns/jakarta-restful-ws.properties
+++ b/src/main/resources/config/jakarta10/mappedPatterns/jakarta-restful-ws.properties
@@ -1,0 +1,46 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-restful-ws-method-change-must-favor-jsonb=ws.rs.ext.ContextResolver
+jakarta-restful-ws-method-change-produces-multipart=ws.rs.Produces@MULTIPART_FORM_DATA
+jakarta-restful-ws-method-change-consumes-multipart=ws.rs.Consumes@MULTIPART_FORM_DATA
+jakarta-restful-ws-method-change-context-deprecated=ws.rs.core.Context@Context
+jakarta-restful-ws-method-change-jaxblink-deprecated=ws.rs.core.Link#JaxbLink
+jakarta-restful-ws-method-change-jaxbadapter-deprecated=ws.rs.core.Link#JaxbAdapter
+jakarta-restful-ws-method-change-cookie-constructor-deprecated=ws.rs.core.Cookie#constructor
+jakarta-restful-ws-method-change-newcookie-constructor-deprecated=ws.rs.core.NewCookie#constructor


### PR DESCRIPTION
This is to map Jakarta RESTful web services 3.1 issues to advisor tool:

Result of tests:
`
[WARNING] Line of code: 8 | Expression: jakarta.ws.rs.ext.ContextResolver
Source file: CustomResolver.java
Jakarta RESTful 3.1
 JSON-B entity providers must favor Jsonb instances provided by ContextResolver<Jsonb>
This issue won't affect your application.
 Whenever you use ContextResolver for JSON-B entities, the recommendation is to use Jsonb instances.

[WARNING] Line of code: 3 | Expression: jakarta.ws.rs.ext.ContextResolver
Source file: CustomResolverWithMapper.java
Jakarta RESTful 3.1
 JSON-B entity providers must favor Jsonb instances provided by ContextResolver<Jsonb>
This issue won't affect your application.
 Whenever you use ContextResolver for JSON-B entities, the recommendation is to use Jsonb instances.

[WARNING] Line of code: 32 | Expression: new NewCookie(cookie)
Source file: HelloResource.java
Jakarta RESTful 3.1
 Constructors for NewCookie class were deprecated.
This issue won't affect your application.
 The advixe is to change for NewCookie.Builder class.

[WARNING] Line of code: 45 | Expression: @Produces(MediaType.MULTIPART_FORM_DATA)
Source file: HelloResource.java
Jakarta RESTful 3.1
 Now you can process MULTIPART_FORM_DATA with List<EntityPart> as a parameter on the method or by using @FormParam for each of the parts
 indicating the name of the param for the following types: String, InputString or EntityPart
This issue won't affect your application.

[WARNING] Line of code: 30 | Expression: new Cookie("mycookie", "some value")
Source file: HelloResource.java
Jakarta RESTful 3.1
 Constructors for Cookie class were deprecated.
This issue won't affect your application.
 The advice is to change for Cookie.Builder class.

[WARNING] Line of code: 38 | Expression: @Consumes(MediaType.MULTIPART_FORM_DATA)
Source file: HelloResource.java
Jakarta RESTful 3.1
 Now you can process MULTIPART_FORM_DATA with List<EntityPart> as a parameter on the method or by using @FormParam for each of the parts
 indicating the name of the param for the following types: String, InputString or EntityPart
This issue won't affect your application.

[WARNING] Line of code: 29 | Expression: @Context
Source file: HelloResource.java
Jakarta RESTful 3.1
 The @Context annotation is deprecated and future versions of Jakarta RESTful services will no longer support it.
This issue won't affect your application.
 The advice is to use CDI injection instead of @Context.

[WARNING] Line of code: 20 | Expression: Link.JaxbLink.class
Source file: MyModel.java
Jakarta RESTful 3.1
 The JaxbLink class was deprecated and future version of Jakarta RESTful services will no longer support it.
This issue won't affect your application.
 The advice is to stop using the inner class JaxbLink.

[WARNING] Line of code: 14 | Expression: Link.JaxbAdapter.class
Source file: MyModel.java
Jakarta RESTful 3.1
 The JaxbAdapter class was deprecated and future version of Jakarta RESTful services will no longer support it.
This issue won't affect your application.
 The advice is to stop using the inner class JaxbAdapter.
`