### PR TITLE
FISH-6997: mapping tags 3.0 to advisor tool

### DIFF
--- a/src/main/resources/config/jakarta10/advisorFix/jakarta-tags-fix-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorFix/jakarta-tags-fix-messages.properties
@@ -1,0 +1,48 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-tags-namespace-upgrade-core=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-tags-namespace-upgrade-functions=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-tags-namespace-upgrade-fmt=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-tags-namespace-upgrade-sql=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-tags-namespace-upgrade-xml=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.

--- a/src/main/resources/config/jakarta10/advisorMessages/jakarta-tags-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorMessages/jakarta-tags-messages.properties
@@ -1,0 +1,48 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-tags-namespace-upgrade-core=Jakarta Standard Tag Library 3.0 \
+\n The namespace http://java.sun.com/jsp/jstl/core was replaced by jakarta.tags.core
+jakarta-tags-namespace-upgrade-functions=Jakarta Standard Tag Library 3.0 \
+\n The namespace http://java.sun.com/jsp/jstl/functions was replaced by jakarta.tags.functions
+jakarta-tags-namespace-upgrade-fmt=Jakarta Standard Tag Library 3.0 \
+\n The namespace http://java.sun.com/jsp/jstl/fmt was replaced by jakarta.tags.fmt
+jakarta-tags-namespace-upgrade-sql=Jakarta Standard Tag Library 3.0 \
+\n The namespace http://java.sun.com/jsp/jstl/sql was replaced by jakarta.tags.sql
+jakarta-tags-namespace-upgrade-xml=Jakarta Standard Tag Library 3.0 \
+\n The namespace http://java.sun.com/jsp/jstl/xml was replaced by jakarta.tags.xml

--- a/src/main/resources/config/jakarta10/mappedPatterns/jakarta-tags.properties
+++ b/src/main/resources/config/jakarta10/mappedPatterns/jakarta-tags.properties
@@ -1,0 +1,43 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-tags-namespace-upgrade-core=http://java.sun.com/jsp/jstl/core
+jakarta-tags-namespace-upgrade-functions=http://java.sun.com/jsp/jstl/functions
+jakarta-tags-namespace-upgrade-fmt=http://java.sun.com/jsp/jstl/fmt
+jakarta-tags-namespace-upgrade-sql=http://java.sun.com/jsp/jstl/sql
+jakarta-tags-namespace-upgrade-xml=http://java.sun.com/jsp/jstl/xml


### PR DESCRIPTION
This is to map the issues from Jakarta Standard Tag Library 3.0 to Upgrade Advisor Tool

Result of tests:
`
[WARNING] Line of code: - | Expression: namespace:http://java.sun.com/jsp/jstl/sql was replaced
Source file: index.jsp
Jakarta Standard Tag Library 3.0
 The namespace http://java.sun.com/jsp/jstl/sql was replaced by jakarta.tags.sql
This issue won't affect your application.
 To prevent future issues replace old namespaces with the new.

[WARNING] Line of code: - | Expression: namespace:http://java.sun.com/jsp/jstl/fmt was replaced
Source file: index.jsp
Jakarta Standard Tag Library 3.0
 The namespace http://java.sun.com/jsp/jstl/fmt was replaced by jakarta.tags.fmt
This issue won't affect your application.
 To prevent future issues replace old namespaces with the new.

[WARNING] Line of code: - | Expression: namespace:http://java.sun.com/jsp/jstl/xml was replaced
Source file: index.jsp
Jakarta Standard Tag Library 3.0
 The namespace http://java.sun.com/jsp/jstl/xml was replaced by jakarta.tags.xml
This issue won't affect your application.
 To prevent future issues replace old namespaces with the new.

[WARNING] Line of code: - | Expression: namespace:http://java.sun.com/jsp/jstl/functions was replaced
Source file: index.jsp
Jakarta Standard Tag Library 3.0
 The namespace http://java.sun.com/jsp/jstl/functions was replaced by jakarta.tags.functions
This issue won't affect your application.
 To prevent future issues replace old namespaces with the new.

[WARNING] Line of code: - | Expression: namespace:http://java.sun.com/jsp/jstl/core was replaced
Source file: index.jsp
Jakarta Standard Tag Library 3.0
 The namespace http://java.sun.com/jsp/jstl/core was replaced by jakarta.tags.core
This issue won't affect your application.
 To prevent future issues replace old namespaces with the new.

`