### PR TITLE
Fish-7450: mapping jakarta faces 4.0 to advisor tool

### DIFF
--- a/src/main/java/fish/payara/advisor/AdvisorBean.java
+++ b/src/main/java/fish/payara/advisor/AdvisorBean.java
@@ -77,7 +77,7 @@ public class AdvisorBean {
         if (obj instanceof AdvisorBean) {
             final AdvisorBean other = (AdvisorBean) obj;
             return this.file.equals(other.file) && this.line.equals(other.line)
-                    && this.keyPattern.equals(other.keyPattern) && this.valuePattern.equals(other.valuePattern);
+                    && this.valuePattern.equals(other.valuePattern);
         }
         return false;
     }

--- a/src/main/java/fish/payara/advisor/AdvisorConstructorCall.java
+++ b/src/main/java/fish/payara/advisor/AdvisorConstructorCall.java
@@ -41,6 +41,7 @@ package fish.payara.advisor;
 
 import com.github.javaparser.Position;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import java.util.List;
@@ -86,6 +87,22 @@ public class AdvisorConstructorCall extends AdvisorMethodCall implements Advisor
                             AdvisorBeanBuilder(keyPattern, valuePattern).
                             setLine((p.map(position -> "" + position.line).orElse(""))).
                             setMethodDeclaration(objectCreationExpr.toString()).build();
+                    advisorBeans.add(advisorMethodBean);
+                }
+            }
+        }
+
+        @Override
+        public void visit(ExplicitConstructorInvocationStmt explicitConstructorInvocationStmt,
+                          List<AdvisorBean> advisorBeans) {
+            super.visit(explicitConstructorInvocationStmt, advisorBeans);
+            Optional<Position> p = explicitConstructorInvocationStmt.getBegin();
+            if(explicitConstructorInvocationStmt.isExplicitConstructorInvocationStmt()) {
+                if (params.length == 0) {
+                    AdvisorBean advisorMethodBean = new AdvisorBean.
+                            AdvisorBeanBuilder(keyPattern, valuePattern).
+                            setLine((p.map(position -> "" + position.line).orElse(""))).
+                            setMethodDeclaration(explicitConstructorInvocationStmt.toString()).build();
                     advisorBeans.add(advisorMethodBean);
                 }
             }

--- a/src/main/java/fish/payara/advisor/AdvisorFieldCall.java
+++ b/src/main/java/fish/payara/advisor/AdvisorFieldCall.java
@@ -1,0 +1,85 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.advisor;
+
+import com.github.javaparser.Position;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.visitor.VoidVisitor;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import java.util.List;
+import java.util.Optional;
+
+public class AdvisorFieldCall implements AdvisorInterface {
+
+    @Override
+    public VoidVisitor<List<AdvisorBean>> createVoidVisitor(String keyPattern, String valuePattern, String... params) {
+        return new AdvisorFieldCall.FieldCallCollector(keyPattern, valuePattern, params);
+    }
+
+    @Override
+    public VoidVisitor<List<AdvisorBean>> createVoidVisitor(String keyPattern, String valuePattern, String secondPattern) {
+        return null;
+    }
+
+    private static class FieldCallCollector extends VoidVisitorAdapter<List<AdvisorBean>> {
+
+        private final String keyPattern;
+        private final String valuePattern;
+        private final String[] params;
+
+        public FieldCallCollector(String keyPattern, String valuePattern, String... params) {
+            this.keyPattern = keyPattern;
+            this.valuePattern = valuePattern;
+            this.params = params;
+        }
+
+        @Override
+        public void visit(FieldAccessExpr fieldAccessExpr, List<AdvisorBean> advisorBeanList) {
+            super.visit(fieldAccessExpr, advisorBeanList);
+            Optional<Position> p = fieldAccessExpr.getBegin();
+            if(fieldAccessExpr.isFieldAccessExpr() && fieldAccessExpr.toString().contains(valuePattern)) {
+                AdvisorBean advisorFieldBean = new AdvisorBean.AdvisorBeanBuilder(keyPattern, valuePattern).
+                        setLine((p.map(position -> "" + position.line).orElse("")))
+                        .setMethodDeclaration(fieldAccessExpr.toString()).build();
+                advisorBeanList.add(advisorFieldBean);
+            }
+        }
+    }
+}

--- a/src/main/java/fish/payara/advisor/AdvisorMethodCall.java
+++ b/src/main/java/fish/payara/advisor/AdvisorMethodCall.java
@@ -77,6 +77,7 @@ public class AdvisorMethodCall implements AdvisorInterface {
             this.params = params;
         }
 
+        @Override
         public void visit(MethodCallExpr methodCall, List<AdvisorBean> collector) {
             super.visit(methodCall, collector);
             Optional<Position> p = methodCall.getBegin();

--- a/src/main/resources/config/jakarta10/advisorFix/jakarta-faces-fix-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorFix/jakarta-faces-fix-messages.properties
@@ -1,0 +1,190 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-faces-namespace-upgrade-component=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-faces-namespace-upgrade-composite=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-faces-namespace-upgrade-passthrough=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-faces-namespace-upgrade-html=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-faces-namespace-upgrade-core=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-faces-namespace-upgrade-facelets=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-faces-namespace-upgrade-jsf=This issue won't affect your application. \n \
+To prevent future issues replace old namespaces with the new.
+jakarta-faces-namespace-upgrade-xmlns-jsf=This issue won't affect your application. \n \
+To prevent future issues replace prefix with the new more appropriated without use of jsf.
+jakarta-faces-namespace-upgrade-xmlns=This issue won't affect your application. \n \
+To prevent future issues replace prefix with the new more appropriated without use of jsf.
+jakarta-faces-remove-resolver=Your application won't work, \
+  please remove ResourceResolver class because it will not compile in Jakarta EE 10
+jakarta-faces-remove-state-manager-1=Your application won't work, \
+  please remove StateManager.saveSerializedView(FacesContext context) call.
+jakarta-faces-remove-state-manager-2=Your application won't work, \
+  please remove StateManager.saveView(FacesContext context) call.
+jakarta-faces-remove-state-manager-3=Your application won't work, \
+  please remove StateManager.getTreeStructureToSave(FacesContext context) call.
+jakarta-faces-remove-state-manager-4=Your application won't work, \
+  please remove StateManager.getComponentStateToSave(FacesContext context) call.
+jakarta-faces-remove-state-manager-5=Your application won't work, \
+  please remove StateManager.writeState(FacesContext context, SerializedView state) call.
+jakarta-faces-remove-state-manager-6=Your application won't work, \
+  please remove StateManager.restoreView(FacesContext facesContext, String s, String s1) call.
+jakarta-faces-remove-state-manager-7=Your application won't work, \
+  please remove StateManager.restoreTreeStructure(FacesContext context, String viewId, String renderKitId) call.
+jakarta-faces-remove-state-manager-8=Your application won't work, \
+  please remove StateManager.restoreComponentState(FacesContext context, UIViewRoot viewRoot, String renderKitId) call.
+jakarta-faces-remove-state-manager-9=Your application won't work, \
+  please remove StateManager.SerializedView call.
+jakarta-faces-remove-state-manager-10=Your application won't work, \
+  please remove call for empty constructor for the class StateManagerWrapper
+jakarta-faces-remove-state-manager-11=Your application won't work, \
+  please remove StateManagerWrapper.saveSerializedView(FacesContext context) call for any of the available subclasses.
+jakarta-faces-remove-state-manager-12=Your application won't work, \
+  please remove StateManagerWrapper.saveView(FacesContext context) call for any of the available subclasses.
+jakarta-faces-remove-state-manager-13=Your application won't work, \
+  please remove StateManagerWrapper.getTreeStructureToSave(FacesContext context) \
+  call for any of the available subclasses.
+jakarta-faces-remove-state-manager-14=Your application won't work, \
+  please remove StateManagerWrapper.getComponentStateToSave(FacesContext context) \
+  call for any of the available subclasses.
+jakarta-faces-remove-state-manager-15=Your application won't work, \
+  please remove StateManagerWrapper.writeState(FacesContext context, SerializedView state) call \
+  for any of the available subclasses.
+jakarta-faces-remove-state-manager-16=Your application won't work, \
+  please remove StateManagerWrapper.restoreView(FacesContext context, String viewId, String renderKitId) \
+   call for any of the available subclasses.
+jakarta-faces-remove-state-manager-17=Your application won't work, \
+  please remove StateManagerWrapper.restoreTreeStructure(FacesContext context, String viewId, String renderKitId) \
+   call for any of the available subclasses.
+jakarta-faces-remove-state-manager-18=Your application won't work, \
+\n please remove StateManagerWrapper.restoreComponentState(FacesContext context, UIViewRoot viewRoot, String renderKitId) \
+   call for any of the available subclasses.
+jakarta-faces-remove-constant-name-1=Your application won't work, \
+\n please remove UIComponent.CURRENT_COMPONENT call, instead use method UIComponent.getCurrentComponent() from the class.
+jakarta-faces-remove-constant-name-2=Your application won't work, \
+\n please remove UIComponent.CURRENT_COMPOSITE_COMPONENT call, \ \
+  instead use method UIComponent.getCurrentCompositeComponent() from the class.
+jakarta-faces-remove-constant-name-3=Your application won't work, \
+  please remove UIComponent.HONOR_CURRENT_COMPONENT_ATTRIBUTES_PARAM_NAME call.
+jakarta-faces-remove-mbinding=Your application won't work, \
+\n please remove class MethodBinding and replace with the class \
+  jakarta.el.MethodExpression from Jakarta Expression Language
+jakarta-faces-remove-valuebinding=Your application won't work, \
+\n please remove class ValueBinding and replace with the class \
+  jakarta.el.ValueExpression from Jakarta Expression Language
+jakarta-faces-remove-variableresolver=Your application won't work, \
+\n please remove class VariableResolver and replace with the class \
+  jakarta.el.ELResolver from Jakarta Expression Language
+jakarta-faces-remove-referencesyntax=Your application won't work, \
+\n please remove class ReferenceSyntaxException and replace with the class \
+  jakarta.el.ELException from Jakarta Expression Language
+jakarta-faces-remove-propertyresolver=Your application won't work, \
+\n please remove class PropertyResolver and replace with the class \
+  jakarta.el.ELResolver from Jakarta Expression Language
+jakarta-faces-remove-propertynotfound=Your application won't work, \
+\n please remove class PropertyNotFoundException and replace with the class \
+  jakarta.el.PropertyNotFoundException from Jakarta Expression Language
+jakarta-faces-remove-mnotfoundexception=Your application won't work, \
+\n please remove class MethodNotFoundException and replace with the class \
+  jakarta.el.MethodNotFoundException from Jakarta Expression Language
+jakarta-faces-remove-evaluationexception=Your application won't work, \
+\n please remove class EvaluationException and replace with the class \
+  jakarta.el.ELException from Jakarta Expression Language
+jakarta-faces-remove-legacyvaluebinding=Your application won't work, \
+\n please remove class LegacyValueBinding and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-legacymbinding=Your application won't work, \
+\n please remove class LegacyMethodBinding and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-legacyelcontext=Your application won't work, \
+\n please remove class LegacyELContext and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-mbindingvalue=Your application won't work, \
+\n please remove class MethodBindingValueChangeListener and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-mbindingvalidator=Your application won't work, \
+\n please remove class MethodBindingValidator and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-mbindingadapter=Your application won't work, \
+\n please remove class MethodBindingAdapterBase and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-variableresolverimpl=Your application won't work, \
+\n please remove class VariableResolverImpl and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-variableresolverchain=Your application won't work, \
+\n please remove class VariableResolverChainWrapper and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-propertyresolverimpl=Your application won't work, \
+\n please remove class PropertyResolverImpl and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-propertyresolverchain=Your application won't work, \
+\n please remove class PropertyResolverChainWrapper and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-dummyproperty=Your application won't work, \
+\n please remove class DummyPropertyResolverImpl and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-chainawarevariable=Your application won't work, \
+\n please remove class ChainAwareVariableResolver and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-valueexpression=Your application won't work, \
+\n please remove class ValueExpressionValueBindingAdapter and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-valuebindingvalue=Your application won't work, \
+\n please remove class ValueBindingValueExpressionAdapter and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-mexpressionadapter=Your application won't work, \
+\n please remove class MethodExpressionMethodBindingAdapter and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-mbindingmexpression=Your application won't work, \
+\n please remove class MethodBindingMethodExpressionAdapter and replace with new classes from Jakarta Expression Language
+jakarta-faces-remove-applicationscoped=Your application won't work, \
+\n please remove class jakarta.faces.bean.ApplicationScoped and replace with \
+\n class jakarta.enterprise.context.ApplicationScoped that is a CDI build-in scope
+jakarta-faces-remove-customscoped=Your application won't work, \
+\n please remove class jakarta.faces.bean.CustomScoped and replace with \
+\n CDI custom scopes and jakarta.enterprise.context.spi.Context
+jakarta-faces-remove-managedbean=Your application won't work, \
+\n please remove class jakarta.faces.bean.ManagedBean and replace with \
+\n CDI scopes and naming
+jakarta-faces-remove-managedproperty=Your application won't work, \
+\n please remove class jakarta.faces.bean.ManagedProperty and replace with \
+\n class jakarta.faces.annotation.ManagedProperty
+jakarta-faces-remove-nonescoped=Your application won't work, \
+\n please remove class jakarta.faces.bean.NoneScoped and replace with \
+\n class jakarta.enterprise.context.Dependent from CDI
+jakarta-faces-remove-referencedbean=Your application won't work, \
+\n please remove class jakarta.faces.bean.ReferencedBean. \
+\n There is no direct replacement for this other than using the XML variant in faces-config.xml
+jakarta-faces-remove-requestscoped=Your application won't work, \
+\n please remove class jakarta.faces.bean.RequestScoped and replace with \
+\n class jakarta.enterprise.context.RequestScoped that is a CDI build-in scope
+jakarta-faces-remove-sesionscoped=Your application won't work, \
+\n please remove class jakarta.faces.bean.SessionScoped and replace with \
+\n class jakarta.enterprise.context.SessionScoped that is a CDI build-in scope
+jakarta-faces-remove-viewscoped=Your application won't work, \
+\n please remove class jakarta.faces.bean.ViewScoped and replace with \
+\n class jakarta.faces.view.ViewScoped that is a CDI custom scope

--- a/src/main/resources/config/jakarta10/advisorMessages/jakarta-faces-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorMessages/jakarta-faces-messages.properties
@@ -1,0 +1,166 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-faces-namespace-upgrade-component=Jakarta Faces 4.0 issue 1553 \
+\n The namespace http://xmlns.jcp.org/jsf/component was replaced by jakarta.faces.component
+jakarta-faces-namespace-upgrade-composite=Jakarta Faces 4.0 issue 1553 \
+\n The namespace http://xmlns.jcp.org/jsf/composite was replaced by jakarta.faces.composite
+jakarta-faces-namespace-upgrade-passthrough=Jakarta Faces 4.0 issue 1553 \
+\n The namespace http://xmlns.jcp.org/jsf/passthrough was replaced by jakarta.faces.passthrough
+jakarta-faces-namespace-upgrade-html=Jakarta Faces 4.0 issue 1553 \
+\n The namespace http://xmlns.jcp.org/jsf/html was replaced by jakarta.faces.html
+jakarta-faces-namespace-upgrade-core=Jakarta Faces 4.0 issue 1553 \
+\n The namespace http://xmlns.jcp.org/jsf/core was replaced by jakarta.faces.core
+jakarta-faces-namespace-upgrade-facelets=Jakarta Faces 4.0 issue 1553 \
+\n The namespace http://xmlns.jcp.org/jsf/facelets was replaced by jakarta.faces.facelets
+jakarta-faces-namespace-upgrade-jsf=Jakarta Faces 4.0 issue 1553 \
+\n The namespace http://xmlns.jcp.org/jsf was replaced by jakarta.faces
+jakarta-faces-namespace-upgrade-xmlns-jsf=Jakarta Faces 4.0 issue 1552 \
+\n The use of the prefix xmlns:jsf should need to be replaced by xmlns:faces
+jakarta-faces-namespace-upgrade-xmlns=Jakarta Faces 4.0 issue 1552 \
+  \n The use of the namespace prefix jsf: should need to be replaced by faces:
+jakarta-faces-remove-resolver=Jakarta Faces 4.0 issue 1583 \
+  \n Since 4.0 deprecated ResourceResolver class was removed. Instead use ResourceHandler class.
+jakarta-faces-remove-state-manager-1=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method saveSerializedView from StateManager class was removed.
+jakarta-faces-remove-state-manager-2=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method saveView from StateManager class was removed.
+jakarta-faces-remove-state-manager-3=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method getTreeStructureToSave from StateManager class was removed.
+jakarta-faces-remove-state-manager-4=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method getComponentStateToSave from StateManager class was removed.
+jakarta-faces-remove-state-manager-5=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method writeState from StateManager class was removed.
+jakarta-faces-remove-state-manager-6=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method restoreView from StateManager class was removed.
+jakarta-faces-remove-state-manager-7=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method restoreTreeStructure from StateManager class was removed.
+jakarta-faces-remove-state-manager-8=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method restoreComponentState from StateManager class was removed.
+jakarta-faces-remove-state-manager-9=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated SerializedView inner class was removed.
+jakarta-faces-remove-state-manager-10=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated constructor for StateManagerWrapper class was removed.
+jakarta-faces-remove-state-manager-11=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method saveSerializedView from StateManagerWrapper class was removed.
+jakarta-faces-remove-state-manager-12=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method saveView from StateManagerWrapper class was removed.
+jakarta-faces-remove-state-manager-13=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method getTreeStructureToSave from StateManagerWrapper class was removed.
+jakarta-faces-remove-state-manager-14=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method getComponentStateToSave from StateManagerWrapper class was removed.
+jakarta-faces-remove-state-manager-15=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method writeState from StateManagerWrapper class was removed.
+jakarta-faces-remove-state-manager-16=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method restoreView from StateManagerWrapper class was removed.
+jakarta-faces-remove-state-manager-17=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method restoreTreeStructure from StateManagerWrapper class was removed.
+jakarta-faces-remove-state-manager-18=Jakarta Faces 4.0 issue 1578 \
+  \n Since 4.0 deprecated method restoreComponentState from StateManagerWrapper class was removed.
+jakarta-faces-remove-constant-name-1=Jakarta Faces 4.0 issue 1571 \
+  \n Since 4.0 deprecated constant CURRENT_COMPONENT from UIComponent class was removed.
+jakarta-faces-remove-constant-name-2=Jakarta Faces 4.0 issue 1571 \
+  \n Since 4.0 deprecated constant CURRENT_COMPOSITE_COMPONENT from UIComponent class was removed.
+jakarta-faces-remove-constant-name-3=Jakarta Faces 4.0 issue 1571 \
+\n Since 4.0 deprecated constant HONOR_CURRENT_COMPONENT_ATTRIBUTES_PARAM_NAME from UIComponent class was removed.
+jakarta-faces-remove-mbinding=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like MethodBinding used for old EL implementation was removed.
+jakarta-faces-remove-valuebinding=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like ValueBinding used for old EL implementation was removed.
+jakarta-faces-remove-variableresolver=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like VariableResolver used for old EL implementation was removed.
+jakarta-faces-remove-referencesyntax=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like ReferenceSyntaxException used for old EL implementation was removed.
+jakarta-faces-remove-propertyresolver=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like PropertyResolver used for old EL implementation was removed.
+jakarta-faces-remove-propertynotfound=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like PropertyNotFoundException used for old EL implementation was removed.
+jakarta-faces-remove-mnotfoundexception=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like MethodNotFoundException used for old EL implementation was removed.
+jakarta-faces-remove-evaluationexception=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like EvaluationException used for old EL implementation was removed.
+jakarta-faces-remove-legacyvaluebinding=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like LegacyValueBinding used for old EL implementation was removed.
+jakarta-faces-remove-legacymbinding=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like LegacyMethodBinding used for old EL implementation was removed.
+jakarta-faces-remove-legacyelcontext=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like LegacyELContext used for old EL implementation was removed.
+jakarta-faces-remove-mbindingvalue=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like MethodBindingValueChangeListener used for old EL implementation was removed.
+jakarta-faces-remove-mbindingvalidator=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like MethodBindingValidator used for old EL implementation was removed.
+jakarta-faces-remove-mbindingadapter=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like MethodBindingAdapterBase used for old EL implementation was removed.
+jakarta-faces-remove-variableresolverimpl=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like VariableResolverImpl used for old EL implementation was removed.
+jakarta-faces-remove-variableresolverchain=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like VariableResolverChainWrapper used for old EL implementation was removed.
+jakarta-faces-remove-propertyresolverimpl=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like PropertyResolverImpl used for old EL implementation was removed.
+jakarta-faces-remove-propertyresolverchain=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like PropertyResolverChainWrapper used for old EL implementation was removed.
+jakarta-faces-remove-dummyproperty=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like DummyPropertyResolverImpl used for old EL implementation was removed.
+jakarta-faces-remove-chainawarevariable=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like ChainAwareVariableResolver used for old EL implementation was removed.
+jakarta-faces-remove-valueexpression=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like ValueExpressionValueBindingAdapter used for old EL implementation was removed.
+jakarta-faces-remove-valuebindingvalue=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like ValueBindingValueExpressionAdapter used for old EL implementation was removed.
+jakarta-faces-remove-mexpressionadapter=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like MethodExpressionMethodBindingAdapter used for old EL implementation was removed.
+jakarta-faces-remove-mbindingmexpression=Jakarta Faces 4.0 issue 1548 \
+\n Since 4.0 deprecated classes like MethodBindingMethodExpressionAdapter used for old EL implementation was removed.
+jakarta-faces-remove-applicationscoped=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.ApplicationScoped related to manage bean system was removed.
+jakarta-faces-remove-customscoped=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.CustomScoped related to manage bean system was removed.
+jakarta-faces-remove-managedbean=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.ManagedBean related to manage bean system was removed.
+jakarta-faces-remove-managedproperty=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.ManagedProperty related to manage bean system was removed.
+jakarta-faces-remove-nonescoped=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.NoneScoped related to manage bean system was removed.
+jakarta-faces-remove-referencedbean=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.ReferencedBean related to manage bean system was removed.
+jakarta-faces-remove-requestscoped=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.RequestScoped related to manage bean system was removed.
+jakarta-faces-remove-sesionscoped=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.SessionScoped related to manage bean system was removed.
+jakarta-faces-remove-viewscoped=Jakarta Faces 4.0 issue 1547 \
+\n Since 4.0 deprecated classes like jakarta.faces.bean.ViewScoped related to manage bean system was removed.

--- a/src/main/resources/config/jakarta10/mappedPatterns/jakarta-faces.properties
+++ b/src/main/resources/config/jakarta10/mappedPatterns/jakarta-faces.properties
@@ -1,0 +1,103 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-faces-namespace-upgrade-component-warn=http://xmlns.jcp.org/jsf/component
+jakarta-faces-namespace-upgrade-composite-warn=http://xmlns.jcp.org/jsf/composite
+jakarta-faces-namespace-upgrade-passthrough-warn=http://xmlns.jcp.org/jsf/passthrough
+jakarta-faces-namespace-upgrade-html-warn=http://xmlns.jcp.org/jsf/html
+jakarta-faces-namespace-upgrade-core-warn=http://xmlns.jcp.org/jsf/core
+jakarta-faces-namespace-upgrade-facelets-warn=http://xmlns.jcp.org/jsf/facelets
+jakarta-faces-namespace-upgrade-jsf-warn="http://xmlns.jcp.org/jsf"
+jakarta-faces-namespace-upgrade-xmlns-jsf-warn=xmlns:jsf
+jakarta-faces-namespace-upgrade-xmlns-warn=jsf:
+jakarta-faces-remove-resolver-error=faces.view.facelets.ResourceResolver
+jakarta-faces-remove-state-manager-1-error=faces.application.StateManager#saveSerializedView
+jakarta-faces-remove-state-manager-2-error=faces.application.StateManager#saveView
+jakarta-faces-remove-state-manager-3-error=faces.application.StateManager#getTreeStructureToSave
+jakarta-faces-remove-state-manager-4-error=faces.application.StateManager#getComponentStateToSave
+jakarta-faces-remove-state-manager-5-error=faces.application.StateManager#writeState(FacesContext, SerializedView)
+jakarta-faces-remove-state-manager-6-error=faces.application.StateManager#restoreView
+jakarta-faces-remove-state-manager-7-error=faces.application.StateManager#restoreTreeStructure
+jakarta-faces-remove-state-manager-8-error=faces.application.StateManager#restoreComponentState
+jakarta-faces-remove-state-manager-9-error=faces.application.StateManager#SerializedView
+jakarta-faces-remove-state-manager-10-error=faces.application.StateManagerWrapper#constructor
+jakarta-faces-remove-state-manager-11-error=faces.application.StateManagerWrapper#saveSerializedView
+jakarta-faces-remove-state-manager-12-error=faces.application.StateManagerWrapper#saveView
+jakarta-faces-remove-state-manager-13-error=faces.application.StateManagerWrapper#getTreeStructureToSave
+jakarta-faces-remove-state-manager-14-error=faces.application.StateManagerWrapper#getComponentStateToSave
+jakarta-faces-remove-state-manager-15-error=faces.application.StateManagerWrapper#writeState(FacesContext, SerializedView)
+jakarta-faces-remove-state-manager-16-error=faces.application.StateManagerWrapper#restoreView
+jakarta-faces-remove-state-manager-17-error=faces.application.StateManagerWrapper#restoreTreeStructure
+jakarta-faces-remove-state-manager-18-error=faces.application.StateManagerWrapper#restoreComponentState
+jakarta-faces-remove-constant-name-1-error=faces.component.UIComponent#constant.CURRENT_COMPONENT
+jakarta-faces-remove-constant-name-2-error=faces.component.UIComponent#constant.CURRENT_COMPOSITE_COMPONENT
+jakarta-faces-remove-constant-name-3-error=faces.component.UIComponent#constant.HONOR_CURRENT_COMPONENT_ATTRIBUTES_PARAM_NAME
+jakarta-faces-remove-mbinding-error=faces.el.MethodBinding
+jakarta-faces-remove-valuebinding-error=faces.el.ValueBinding
+jakarta-faces-remove-variableresolver-error=faces.el.VariableResolver
+jakarta-faces-remove-referencesyntax-error=faces.el.ReferenceSyntaxException
+jakarta-faces-remove-propertyresolver-error=faces.el.PropertyResolver
+jakarta-faces-remove-propertynotfound-error=faces.el.PropertyNotFoundException
+jakarta-faces-remove-mnotfoundexception-error=faces.el.MethodNotFoundException
+jakarta-faces-remove-evaluationexception-error=faces.el.EvaluationException
+jakarta-faces-remove-legacyvaluebinding-error=com.sun.faces.facelets.el.LegacyValueBinding
+jakarta-faces-remove-legacymbinding-error=com.sun.faces.facelets.el.LegacyMethodBinding
+jakarta-faces-remove-legacyelcontext-error=com.sun.faces.facelets.el.LegacyELContext
+jakarta-faces-remove-mbindingvalue-error=faces.component.MethodBindingValueChangeListener
+jakarta-faces-remove-mbindingvalidator-error=faces.component.MethodBindingValidator
+jakarta-faces-remove-mbindingadapter-error=faces.component.MethodBindingAdapterBase
+jakarta-faces-remove-variableresolverimpl-error=com.sun.faces.el.VariableResolverImpl
+jakarta-faces-remove-variableresolverchain-error=com.sun.faces.el.VariableResolverChainWrapper
+jakarta-faces-remove-propertyresolverimpl-error=com.sun.faces.el.PropertyResolverImpl
+jakarta-faces-remove-propertyresolverchain-error=com.sun.faces.el.PropertyResolverChainWrapper
+jakarta-faces-remove-dummyproperty-error=com.sun.faces.el.DummyPropertyResolverImpl
+jakarta-faces-remove-chainawarevariable-error=com.sun.faces.el.ChainAwareVariableResolver
+jakarta-faces-remove-valueexpression-error=com.sun.faces.application.ValueExpressionValueBindingAdapter
+jakarta-faces-remove-valuebindingvalue-error=com.sun.faces.application.ValueBindingValueExpressionAdapter
+jakarta-faces-remove-mexpressionadapter-error=com.sun.faces.application.MethodExpressionMethodBindingAdapter
+jakarta-faces-remove-mbindingmexpression-error=com.sun.faces.application.MethodBindingMethodExpressionAdapter
+jakarta-faces-remove-applicationscoped-error=faces.bean.ApplicationScoped
+jakarta-faces-remove-customscoped-error=faces.bean.CustomScoped
+jakarta-faces-remove-managedbean-error=faces.bean.ManagedBean
+jakarta-faces-remove-managedproperty-error=faces.bean.ManagedProperty
+jakarta-faces-remove-nonescoped-error=faces.bean.NoneScoped
+jakarta-faces-remove-referencedbean-error=faces.bean.ReferencedBean
+jakarta-faces-remove-requestscoped-error=faces.bean.RequestScoped
+jakarta-faces-remove-sesionscoped-error=faces.bean.SessionScoped
+jakarta-faces-remove-viewscoped-error=faces.bean.ViewScoped
+


### PR DESCRIPTION
Mapping Faces 4.0 to the advisor tool

Reuslt of tests:
`
[ERROR] Line of code: 23 | Expression: myStateManager.saveSerializedView(context)
Source file: MyResourceResolver.java
Jakarta Faces 4.0 issue 1578
 Since 4.0 deprecated SerializedView inner class was removed.
Your application won't work, please remove StateManager.SerializedView call.

[ERROR] Line of code: 38 | Expression: UIComponent.HONOR_CURRENT_COMPONENT_ATTRIBUTES_PARAM_NAME
Source file: MyResourceResolver.java
Jakarta Faces 4.0 issue 1571
 Since 4.0 deprecated constant HONOR_CURRENT_COMPONENT_ATTRIBUTES_PARAM_NAME from UIComponent class was removed.
Your application won't work, please remove UIComponent.HONOR_CURRENT_COMPONENT_ATTRIBUTES_PARAM_NAME call.

[ERROR] Line of code: 23 | Expression: myStateManager.saveSerializedView(context)
Source file: MyResourceResolver.java
Jakarta Faces 4.0 issue 1578
 Since 4.0 deprecated method saveSerializedView from StateManager class was removed.
Your application won't work, please remove StateManager.saveSerializedView(FacesContext context) call.

[ERROR] Line of code: 9 | Expression: jakarta.faces.el.MethodBinding
Source file: MyResourceResolver.java
Jakarta Faces 4.0 issue 1548
 Since 4.0 deprecated classes like MethodBinding used for old EL implementation was removed.
Your application won't work,
 please remove class MethodBinding and replace with the class jakarta.el.MethodExpression from Jakarta Expression Language

[ERROR] Line of code: 25 | Expression: public UIViewRoot restoreView(FacesContext facesContext, String s, String s1)
Source file: MyResourceResolver.java
Jakarta Faces 4.0 issue 1578
 Since 4.0 deprecated method restoreView from StateManager class was removed.
Your application won't work, please remove StateManager.restoreView(FacesContext facesContext, String s, String s1) call.

[ERROR] Line of code: 10 | Expression: jakarta.faces.view.facelets.ResourceResolver
Source file: MyResourceResolver.java
Jakarta Faces 4.0 issue 1583
 Since 4.0 deprecated ResourceResolver class was removed. Instead use ResourceHandler class.
Your application won't work, please remove ResourceResolver class because it will not compile in Jakarta EE 10

[ERROR] Line of code: 36 | Expression: UIComponent.CURRENT_COMPONENT
Source file: MyResourceResolver.java
Jakarta Faces 4.0 issue 1571
 Since 4.0 deprecated constant CURRENT_COMPONENT from UIComponent class was removed.
Your application won't work,
 please remove UIComponent.CURRENT_COMPONENT call, instead use method UIComponent.getCurrentComponent() from the class.
`