### PR TITLE
FISH-7548 Grammar Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mvn fish.payara.advisor:advisor-maven-plugin:1.0-SNAPSHOT:advise
 if a pattern matchs you will see something like the following:
 
 ```
-[INFO] Showing advises
+[INFO] Showing advice
 [INFO] ********
  Jakarta Authorization 2.1
  Issue # 105

--- a/src/main/java/fish/payara/advisor/AdvisorMessageProcessor.java
+++ b/src/main/java/fish/payara/advisor/AdvisorMessageProcessor.java
@@ -167,7 +167,7 @@ public class AdvisorMessageProcessor {
     }
 
     public void printToConsole(List<AdvisorBean> advisorMethodBeanList, Log log) {
-        log.info("Showing Advises");
+        log.info("Showing Advisories");
         log.info("***************");
         advisorMethodBeanList.forEach(b -> {
             if(b.getType() != null) {

--- a/src/main/resources/config/jakarta10/advisorFix/jakarta-restful-ws-fix-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorFix/jakarta-restful-ws-fix-messages.properties
@@ -41,12 +41,12 @@ jakarta-restful-ws-method-change-must-favor-jsonb=This issue won't affect your a
 jakarta-restful-ws-method-change-produces-multipart=This issue won't affect your application. \n
 jakarta-restful-ws-method-change-consumes-multipart=This issue won't affect your application. \n
 jakarta-restful-ws-method-change-context-deprecated=This issue won't affect your application. \n \
-The advise is to use CDI injection instead of @Context.
+The advice is to use CDI injection instead of @Context.
 jakarta-restful-ws-method-change-jaxblink-deprecated=This issue won't affect your application. \n \
-The advise is to stop using the inner class JaxbLink.
+The advice is to stop using the inner class JaxbLink.
 jakarta-restful-ws-method-change-jaxbadapter-deprecated=This issue won't affect your application. \n \
-The advise is to stop using the inner class JaxbAdapter.
+The advice is to stop using the inner class JaxbAdapter.
 jakarta-restful-ws-method-change-cookie-constructor-deprecated=This issue won't affect your application. \n \
-The advise is to change for Cookie.Builder class.
+The advice is to change for Cookie.Builder class.
 jakarta-restful-ws-method-change-newcookie-constructor-deprecated=This issue won't affect your application. \n \
-The advise is to change for NewCookie.Builder class.
+The advice is to change for NewCookie.Builder class.


### PR DESCRIPTION
Fixes some grammar errors.

Advise - verb. To give advice.
Advice - noun, both singular and plural.

Advisory, plural Advisories - pretty much means the same thing as advice, but is typically "formal".

