### PR TITLE
FISH-11994: mapping changes for jakarta annotations 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/fish/payara/advisor/AdvisorLoader.java
+++ b/src/main/java/fish/payara/advisor/AdvisorLoader.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -64,9 +64,10 @@ import org.apache.maven.project.MavenProject;
 public class AdvisorLoader {
 
     private static final Logger log = Logger.getLogger(AdvisorLoader.class.getName());
+
     public Properties loadPatterns(String version) throws URISyntaxException, IOException {
         //validate configurations
-        if(AdvisorToolMojo.class.getClassLoader().getResource("config/jakarta"+version) == null) {
+        if (AdvisorToolMojo.class.getClassLoader().getResource("config/jakarta" + version) == null) {
             log.severe(String.format("Not available configurations for the indicated version %s", version));
             return null;
         }
@@ -74,18 +75,18 @@ public class AdvisorLoader {
                 "config/jakarta" + version + "/mappedPatterns")).toURI();
         Properties readPatterns = new Properties();
         Path internalPath = null;
-        if(uriBaseFolder.getScheme().equals("jar")) {
+        if (uriBaseFolder.getScheme().equals("jar")) {
             FileSystem fileSystem = FileSystems.newFileSystem(uriBaseFolder, Collections.<String, Object>emptyMap());
-            internalPath = fileSystem.getPath("config/jakarta"+version+"/mappedPatterns");
+            internalPath = fileSystem.getPath("config/jakarta" + version + "/mappedPatterns");
         } else {
             internalPath = Paths.get(uriBaseFolder);
         }
         Stream<Path> walk = Files.walk(internalPath, 1);
-        for (Iterator<Path> it = walk.iterator(); it.hasNext();){
+        for (Iterator<Path> it = walk.iterator(); it.hasNext(); ) {
             Path p = it.next();
-            if(p.getFileName().toString().contains(".properties")) {
-                try(InputStream stream = AdvisorToolMojo.class.getClassLoader().getResourceAsStream(p.toString())) {
-                    if(stream == null) {
+            if (p.getFileName().toString().contains(".properties")) {
+                try (InputStream stream = AdvisorToolMojo.class.getClassLoader().getResourceAsStream(p.toString())) {
+                    if (stream == null) {
                         File f = p.toFile();
                         FileInputStream fileInputStream = new FileInputStream(f);
                         readPatterns.load(fileInputStream);
@@ -99,8 +100,8 @@ public class AdvisorLoader {
     }
 
     public List<File> loadSourceFiles(File baseDir) throws IOException {
-        List<File>javaFiles = new ArrayList<>();
-        if(baseDir != null) {
+        List<File> javaFiles = new ArrayList<>();
+        if (baseDir != null) {
             javaFiles = Files.walk(Paths.get(baseDir.toURI()))
                     .filter(Files::isRegularFile)
                     .filter(p -> p.toString().endsWith(".java"))
@@ -113,10 +114,10 @@ public class AdvisorLoader {
 
     public List<File> loadJSPandJSFFiles(File baseDir) throws IOException {
         List<File> jspFiles = new ArrayList<>();
-        if(baseDir != null) {
+        if (baseDir != null) {
             jspFiles = Files.walk(Paths.get(baseDir.toURI()))
                     .filter(Files::isRegularFile)
-                    .filter(p->p.toString().endsWith(".jsp") || p.toString().endsWith(".xhtml"))
+                    .filter(p -> p.toString().endsWith(".jsp") || p.toString().endsWith(".xhtml"))
                     .filter(p -> !p.toString().contains(File.separator + "target" + File.separator))
                     .map(Path::toFile)
                     .collect(Collectors.toList());
@@ -126,7 +127,7 @@ public class AdvisorLoader {
 
     public List<File> loadConfigFiles(File baseDir) throws IOException {
         List<File> configFiles = new ArrayList<>();
-        if(baseDir != null) {
+        if (baseDir != null) {
             configFiles = Files.walk(Paths.get(baseDir.toURI()))
                     .filter(Files::isRegularFile).filter(p -> p.toString().endsWith(".xml")
                             || p.toString().endsWith(".properties"))
@@ -136,5 +137,5 @@ public class AdvisorLoader {
         }
         return configFiles;
     }
-    
+
 }

--- a/src/main/java/fish/payara/advisor/AdvisorToolMojo.java
+++ b/src/main/java/fish/payara/advisor/AdvisorToolMojo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -56,12 +56,12 @@ import org.apache.maven.project.MavenProject;
 public class AdvisorToolMojo extends AbstractMojo {
 
     private static final Logger log = Logger.getLogger(AdvisorToolMojo.class.getName());
-    
+
     private static final String ADVISE_VERSION = "adviseVersion";
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
-    @Parameter(property = "advisor-plugin.adviseVersion", defaultValue = "10")
+    @Parameter(property = "advisor-plugin.adviseVersion", required = false, defaultValue = "10")
     private String adviseVersion;
 
     @Override
@@ -71,7 +71,7 @@ public class AdvisorToolMojo extends AbstractMojo {
         Properties properties = System.getProperties();
         AdvisorLoader advisorLoader = new AdvisorLoader();
         AdvisorEvaluator advisorEvaluator = new AdvisorEvaluator();
-        if(properties.getProperty(ADVISE_VERSION) != null) {
+        if (properties.getProperty(ADVISE_VERSION) != null) {
             this.adviseVersion = properties.getProperty(ADVISE_VERSION);
         }
         try {
@@ -88,12 +88,12 @@ public class AdvisorToolMojo extends AbstractMojo {
                     advisorBeans = advisorEvaluator.adviseCode(patterns, files);
                 }
             }
-            
+
             files = advisorLoader.loadJSPandJSFFiles(project.getBasedir());
-            if(!files.isEmpty()) {
+            if (!files.isEmpty()) {
                 advisorEvaluator.adviseJspAndJSFFiles(patterns, advisorBeans, files);
             }
-            
+
             files = advisorLoader.loadConfigFiles(project.getBasedir());
             if (!files.isEmpty()) {
                 advisorEvaluator.adviseConfigFiles(advisorBeans, files);
@@ -108,7 +108,7 @@ public class AdvisorToolMojo extends AbstractMojo {
             throw new RuntimeException(e);
         }
     }
-    
+
     public void setAdviseVersion(String adviseVersion) {
         this.adviseVersion = adviseVersion;
     }

--- a/src/main/resources/config/jakarta10/advisorFix/jakarta-annotations-fix-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorFix/jakarta-annotations-fix-messages.properties
@@ -1,0 +1,41 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-annotations-remove-managedbean=This issue won't affect your application. \
+\n Please try to replace annotation jakarta.annotation.ManagedBean by \
+\n CDI scopes and naming. For future releases this annotation will be removed.

--- a/src/main/resources/config/jakarta10/advisorMessages/jakarta-annotations-messages.properties
+++ b/src/main/resources/config/jakarta10/advisorMessages/jakarta-annotations-messages.properties
@@ -1,0 +1,40 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-annotations-remove-managedbean=Jakarta Annotations 2.1.1 \
+\n Since 2.1.1 the annotation jakarta.annotation.ManagedBean was marked as deprecated.

--- a/src/main/resources/config/jakarta10/mappedPatterns/jakarta-annotations.properties
+++ b/src/main/resources/config/jakarta10/mappedPatterns/jakarta-annotations.properties
@@ -1,0 +1,39 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-annotations-remove-managedbean-warn=jakarta.annotation.ManagedBean

--- a/src/main/resources/config/jakarta11/advisorFix/jakarta-annotations-fix-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorFix/jakarta-annotations-fix-messages.properties
@@ -1,0 +1,41 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-annotations-remove-managedbean=Your application won't work, \
+\n please remove annotation jakarta.annotation.ManagedBean and replace with \
+\n CDI scopes and naming.

--- a/src/main/resources/config/jakarta11/advisorMessages/jakarta-annotations-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorMessages/jakarta-annotations-messages.properties
@@ -1,0 +1,40 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-annotations-remove-managedbean=Jakarta Annotations 3.0 issue 114 \
+\n Since 3.0 the annotation jakarta.annotation.ManagedBean was removed.

--- a/src/main/resources/config/jakarta11/mappedPatterns/jakarta-annotations.properties
+++ b/src/main/resources/config/jakarta11/mappedPatterns/jakarta-annotations.properties
@@ -1,0 +1,39 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-annotations-remove-managedbean-error=jakarta.annotation.ManagedBean


### PR DESCRIPTION
Adding mapping for annotations 3.0 changes:


Testing:

Use the following reproducer:

[AdvisorReproducerExamples.zip](https://github.com/user-attachments/files/22523935/AdvisorReproducerExamples.zip)

on the root folder of the application execute the following command:

for Jakarta 10 we need to indicate that ManagedBean annotation is deprecated. This change was added for the jakarta annotations 2.1.1 version:  

mvn fish.payara.advisor:advisor-maven-plugin:2.0-SNAPSHOT:advise -DadviseVersion=10

<img width="1101" height="178" alt="image" src="https://github.com/user-attachments/assets/ce3bddc3-6392-429a-acb3-1fbd82f148ce" />

for jakarta 11 we need to indicate that ManagedBean annotation was removed: This change was added for the jakarta annotations 3.0

mvn fish.payara.advisor:advisor-maven-plugin:2.0-SNAPSHOT:advise -DadviseVersion=11

<img width="947" height="174" alt="image" src="https://github.com/user-attachments/assets/f8d9c5ac-f608-4ba1-95a2-0aa8ee57cf4c" />


