### PR TITLE
FISH-11992: mapping changes for jakarta authorization 3.0

### DIFF
--- a/src/main/java/fish/payara/advisor/AdvisorEvaluator.java
+++ b/src/main/java/fish/payara/advisor/AdvisorEvaluator.java
@@ -94,7 +94,7 @@ public class AdvisorEvaluator {
         try {
             advisorBean = acimp.parseFile(key, importNameSpace, sourceFile);
             //check if method call
-            if(advisorBean != null) {
+            if(advisorBean != null || importNameSpace.contains("System")) {
                 AdvisorMethodCall amc = new AdvisorMethodCall();
                 String args = "";
                 if (methodCall.contains("(") && methodCall.contains(")")) {

--- a/src/main/resources/config/jakarta11/advisorFix/jakarta-authorization-fix-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorFix/jakarta-authorization-fix-messages.properties
@@ -1,0 +1,47 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-authorization-method-get-security-manager-removed=Your application won't work, \
+  please remove System#getSecurityManager method because it will not compile in Jakarta EE 11.
+jakarta-authorization-remove-policy=Your application won't work, \
+  please replace java.security.Policy class for jakarta.security.jacc.Policy in order to use the \
+new implementation from Jakarta Authorization 3.0.
+jakarta-authorization-remove-policy-factory=Your application won't work, \
+  \n please use jakarta.security.jacc.PolicyFactory in order to configure custom Policy per application.
+jakarta-authorization-remove-policy-factory-provider=Your application won't work, \
+  \n please use jakarta.security.jacc.PolicyFactory in order to configure custom Policy per application.

--- a/src/main/resources/config/jakarta11/advisorMessages/jakarta-authorization-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorMessages/jakarta-authorization-messages.properties
@@ -1,0 +1,47 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-authorization-method-get-security-manager-removed=Jakarta Authorization 3.0 \
+\n Since Jakarta Authorization 3.0 all references for Security Manager were removed.
+jakarta-authorization-remove-policy=Jakarta Authorization 3.0 \
+\n Since Jakarta Authorization 3.0 the java.security.Policy class now was replaced from similar \
+version within the Jakarta Authorization api.
+jakarta-authorization-remove-policy-factory=Jakarta Authorization 3.0 \
+\n Since Jakarta Authorization 3.0 the fish.payara.jacc.JaccConfigurationFactory is not used to register custom Policy per application.
+jakarta-authorization-remove-policy-factory-provider=Jakarta Authorization 3.0 \
+\n Since Jakarta Authorization 3.0 the org.omnifaces.jaccprovider.TestPolicyConfigurationFactory is not used to register custom Policy per application.

--- a/src/main/resources/config/jakarta11/mappedPatterns/jakarta-authorization.properties
+++ b/src/main/resources/config/jakarta11/mappedPatterns/jakarta-authorization.properties
@@ -1,0 +1,42 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-authorization-method-get-security-manager-removed-error=System#getSecurityManager
+jakarta-authorization-remove-policy-error=java.security.Policy
+jakarta-authorization-remove-policy-factory-error=fish.payara.jacc.JaccConfigurationFactory
+jakarta-authorization-remove-policy-factory-provider-error=org.omnifaces.jaccprovider.TestPolicyConfigurationFactory


### PR DESCRIPTION
Adding mapping for authorization 3.0 changes

Testing

Use the following reproducer:
[AdvisorReproducerExamples.zip](https://github.com/user-attachments/files/22607758/AdvisorReproducerExamples.zip)

on the root folder of the application execute the following command:

-  mvn fish.payara.advisor:advisor-maven-plugin:2.0-SNAPSHOT:advise -DadviseVersion=11

for Jakarta Authorization we need to indicate the removal of the SecurityManager reference:

<img width="1450" height="126" alt="image" src="https://github.com/user-attachments/assets/95511735-56e4-4b89-aa11-b717dc572e69" />

We need to indicate that the way to register custom Policy per app changes and older classes now cause errors on the implementation:

<img width="1826" height="403" alt="image" src="https://github.com/user-attachments/assets/ff110810-f340-4c83-a140-f6d6c7c5e43e" />



