### PR TITLE
Fish 11995 mapping rules for concurrency 3.1

### DIFF
--- a/src/main/resources/config/jakarta11/advisorFix/jakarta-concurrency-fix-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorFix/jakarta-concurrency-fix-messages.properties
@@ -49,7 +49,7 @@ jakarta-concurrency-interface-upgrade-injection-context-service=This issue won't
 jakarta-concurrency-interface-upgrade-injection-managed-executor=This issue won't affect your application. \
   \n You can inject default resources using @Inject instead of @Resource. In case you need \
   \n to specify custom configuration it is better to continue with @Resource, in other case @Inject will be enough.
-jakarta-concurrency-interface-upgrade-injection-managed-shedule-executor=This issue won't affect your application. \
+jakarta-concurrency-interface-upgrade-injection-managed-schedule-executor=This issue won't affect your application. \
   \n You can inject default resources using @Inject instead of @Resource. In case you need \
   \n to specify custom configuration it is better to continue with @Resource, in other case @Inject will be enough.
 jakarta-concurrency-interface-upgrade-injection-managed-thread=This issue won't affect your application. \

--- a/src/main/resources/config/jakarta11/advisorFix/jakarta-concurrency-fix-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorFix/jakarta-concurrency-fix-messages.properties
@@ -1,0 +1,57 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-concurrency-interface-upgrade-schedule=This issue won't affect your application. \
+  \n The recommendation is to start to replace old way to define Scheduled task from EJB with a modern way \
+ \n using Concurrency CDI improvements, please check the class jakarta.enterprise.concurrent.Asynchronous.
+jakarta-concurrency-interface-upgrade-asynchronous=This issue won't affect your application. \
+  \n If you need to provide repeated execution of a method, now you can provide that functionality using Concurrency API \
+  \n without the need to use EJB, please check the class jakarta.enterprise.concurrent.Asynchronous and jakarta.enterprise.concurrent.Schedule \
+  \n to review details for implementation.
+jakarta-concurrency-interface-upgrade-injection-context-service=This issue won't affect your application. \
+  \n You can inject default resources using @Inject instead of @Resource. In case you need \
+  \n to specify custom configuration it is better to continue with @Resource, in other case @Inject will be enough.
+jakarta-concurrency-interface-upgrade-injection-managed-executor=This issue won't affect your application. \
+  \n You can inject default resources using @Inject instead of @Resource. In case you need \
+  \n to specify custom configuration it is better to continue with @Resource, in other case @Inject will be enough.
+jakarta-concurrency-interface-upgrade-injection-managed-shedule-executor=This issue won't affect your application. \
+  \n You can inject default resources using @Inject instead of @Resource. In case you need \
+  \n to specify custom configuration it is better to continue with @Resource, in other case @Inject will be enough.
+jakarta-concurrency-interface-upgrade-injection-managed-thread=This issue won't affect your application. \
+  \n You can inject default resources using @Inject instead of @Resource. In case you need \
+  \n to specify custom configuration it is better to continue with @Resource, in other case @Inject will be enough.

--- a/src/main/resources/config/jakarta11/advisorMessages/jakarta-concurrency-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorMessages/jakarta-concurrency-messages.properties
@@ -44,7 +44,7 @@ jakarta-concurrency-interface-upgrade-injection-context-service=Jakarta Concurre
   \n since Jakarta Concurrency 3.1 you can inject default resources using @Inject instead of @Resource.
 jakarta-concurrency-interface-upgrade-injection-managed-executor=Jakarta Concurrency 3.1 \
   \n since Jakarta Concurrency 3.1 you can inject default resources using @Inject instead of @Resource.
-jakarta-concurrency-interface-upgrade-injection-managed-shedule-executor=Jakarta Concurrency 3.1 \
+jakarta-concurrency-interface-upgrade-injection-managed-schedule-executor=Jakarta Concurrency 3.1 \
   \n since Jakarta Concurrency 3.1 you can inject default resources using @Inject instead of @Resource.
 jakarta-concurrency-interface-upgrade-injection-managed-thread=Jakarta Concurrency 3.1 \
   \n since Jakarta Concurrency 3.1 you can inject default resources using @Inject instead of @Resource.

--- a/src/main/resources/config/jakarta11/advisorMessages/jakarta-concurrency-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorMessages/jakarta-concurrency-messages.properties
@@ -36,12 +36,15 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-jakarta-authorization-method-get-security-manager-removed=Your application won't work, \
-  \n please remove System#getSecurityManager method because it will not compile in Jakarta EE 11.
-jakarta-authorization-remove-policy=Your application won't work, \
-  \n please replace java.security.Policy class for jakarta.security.jacc.Policy in order to use the \
-new implementation from Jakarta Authorization 3.0.
-jakarta-authorization-remove-policy-factory=Your application won't work, \
-  \n please use jakarta.security.jacc.PolicyFactory in order to configure custom Policy per application.
-jakarta-authorization-remove-policy-factory-provider=Your application won't work, \
-  \n please use jakarta.security.jacc.PolicyFactory in order to configure custom Policy per application.
+jakarta-concurrency-interface-upgrade-schedule=Jakarta Concurrency 3.1 \
+  \n since Jakarta Concurrency 3.1 you can configure Asynchronous method call with Schedule configuration.
+jakarta-concurrency-interface-upgrade-asynchronous=Jakarta Concurrency 3.1 \
+  \n since Jakarta Concurrency 3.1 you can indicate for Asynchronous annotation a new property runAt to configure schedules.
+jakarta-concurrency-interface-upgrade-injection-context-service=Jakarta Concurrency 3.1 \
+  \n since Jakarta Concurrency 3.1 you can inject default resources using @Inject instead of @Resource.
+jakarta-concurrency-interface-upgrade-injection-managed-executor=Jakarta Concurrency 3.1 \
+  \n since Jakarta Concurrency 3.1 you can inject default resources using @Inject instead of @Resource.
+jakarta-concurrency-interface-upgrade-injection-managed-shedule-executor=Jakarta Concurrency 3.1 \
+  \n since Jakarta Concurrency 3.1 you can inject default resources using @Inject instead of @Resource.
+jakarta-concurrency-interface-upgrade-injection-managed-thread=Jakarta Concurrency 3.1 \
+  \n since Jakarta Concurrency 3.1 you can inject default resources using @Inject instead of @Resource.

--- a/src/main/resources/config/jakarta11/mappedPatterns/jakarta-concurrency.properties
+++ b/src/main/resources/config/jakarta11/mappedPatterns/jakarta-concurrency.properties
@@ -40,5 +40,5 @@ jakarta-concurrency-interface-upgrade-schedule-info=jakarta.ejb.Schedule
 jakarta-concurrency-interface-upgrade-asynchronous-info=jakarta.enterprise.concurrent.Asynchronous
 jakarta-concurrency-interface-upgrade-injection-context-service-info=jakarta.enterprise.concurrent.ContextService
 jakarta-concurrency-interface-upgrade-injection-managed-executor-info=jakarta.enterprise.concurrent.ManagedExecutorService
-jakarta-concurrency-interface-upgrade-injection-managed-shedule-executor-info=jakarta.enterprise.concurrent.ManagedScheduledExecutorService
+jakarta-concurrency-interface-upgrade-injection-managed-schedule-executor-info=jakarta.enterprise.concurrent.ManagedScheduledExecutorService
 jakarta-concurrency-interface-upgrade-injection-managed-thread-info=jakarta.enterprise.concurrent.ManagedThreadFactory

--- a/src/main/resources/config/jakarta11/mappedPatterns/jakarta-concurrency.properties
+++ b/src/main/resources/config/jakarta11/mappedPatterns/jakarta-concurrency.properties
@@ -36,12 +36,9 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-jakarta-authorization-method-get-security-manager-removed=Your application won't work, \
-  \n please remove System#getSecurityManager method because it will not compile in Jakarta EE 11.
-jakarta-authorization-remove-policy=Your application won't work, \
-  \n please replace java.security.Policy class for jakarta.security.jacc.Policy in order to use the \
-new implementation from Jakarta Authorization 3.0.
-jakarta-authorization-remove-policy-factory=Your application won't work, \
-  \n please use jakarta.security.jacc.PolicyFactory in order to configure custom Policy per application.
-jakarta-authorization-remove-policy-factory-provider=Your application won't work, \
-  \n please use jakarta.security.jacc.PolicyFactory in order to configure custom Policy per application.
+jakarta-concurrency-interface-upgrade-schedule-info=jakarta.ejb.Schedule
+jakarta-concurrency-interface-upgrade-asynchronous-info=jakarta.enterprise.concurrent.Asynchronous
+jakarta-concurrency-interface-upgrade-injection-context-service-info=jakarta.enterprise.concurrent.ContextService
+jakarta-concurrency-interface-upgrade-injection-managed-executor-info=jakarta.enterprise.concurrent.ManagedExecutorService
+jakarta-concurrency-interface-upgrade-injection-managed-shedule-executor-info=jakarta.enterprise.concurrent.ManagedScheduledExecutorService
+jakarta-concurrency-interface-upgrade-injection-managed-thread-info=jakarta.enterprise.concurrent.ManagedThreadFactory


### PR DESCRIPTION
Adding mapping for concurrency 3.1 changes:

Testing:
Use the following reproducer:
[AdvisorReproducerExamples.zip](https://github.com/user-attachments/files/22649765/AdvisorReproducerExamples.zip)

on the root folder of the application execute the following command:

- mvn fish.payara.advisor:advisor-maven-plugin:2.0-SNAPSHOT:advise -DadviseVersion=11

For Jakarta Concurrency 3.1 we need to indicate that the @Schedule annotation can be used in combination of the @Asynchronous annotation as a preferred way instead of the EJB version, to execute a method from a bean on an specified time. This is an introduction of a new property to indicate the Schedules and the creation of a new annotation used to define this functionality:

<img width="1588" height="203" alt="image" src="https://github.com/user-attachments/assets/94d64c6b-088c-410a-8ee5-3a89c5418434" />

<img width="1159" height="182" alt="image" src="https://github.com/user-attachments/assets/608321e5-b72f-43ca-8a6b-f40ad6cc6a9b" />

Additionally, we need to indicate that from Concurrency 3.1 now we can use @Inject to get the Concurrent resources from the server in case we are not providing a custom resource:

<img width="1481" height="702" alt="image" src="https://github.com/user-attachments/assets/c4e7881f-fabe-46a1-ab6a-f35dfedae250" />



