### PR TITLE
FISH-11993 : Add Jakarta Authentication 3.1 migration rules for Secur…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 target/
+/.claude/settings.local.json
+/CLAUDE.md

--- a/src/main/resources/config/jakarta11/advisorFix/jakarta-authentication-fix-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorFix/jakarta-authentication-fix-messages.properties
@@ -1,0 +1,50 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-authentication-issue-138-case-1=Your application won't work. \
+\n Please remove all calls to AuthConfigFactory.getFactorySecurityPermission(). \
+\n SecurityManager-based security checks are no longer supported in Jakarta EE 11. \
+\n Consider using alternative security mechanisms provided by Jakarta Security or your application server.
+jakarta-authentication-issue-138-case-2=Your application won't work. \
+\n Please remove all calls to AuthConfigFactory.setFactorySecurityPermission(Permission). \
+\n SecurityManager-based security checks are no longer supported in Jakarta EE 11. \
+\n Consider using alternative security mechanisms provided by Jakarta Security or your application server.
+jakarta-authentication-issue-138-case-3=Your application won't work. \
+\n Please remove all calls to AuthConfigFactory.providerRegistrationSecurityPermission(String, String). \
+\n SecurityManager-based security checks are no longer supported in Jakarta EE 11. \
+\n Consider using alternative security mechanisms provided by Jakarta Security or your application server.

--- a/src/main/resources/config/jakarta11/advisorMessages/jakarta-authentication-messages.properties
+++ b/src/main/resources/config/jakarta11/advisorMessages/jakarta-authentication-messages.properties
@@ -1,0 +1,50 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+jakarta-authentication-issue-138-case-1=Jakarta Authentication 3.1 Issue # 138 \
+\n The method jakarta.security.auth.message.config.AuthConfigFactory.getFactorySecurityPermission() was removed. \
+\n This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1 \
+\n due to the removal of SecurityManager support in Java 17+.
+jakarta-authentication-issue-138-case-2=Jakarta Authentication 3.1 Issue # 138 \
+\n The method jakarta.security.auth.message.config.AuthConfigFactory.setFactorySecurityPermission(Permission) was removed. \
+\n This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1 \
+\n due to the removal of SecurityManager support in Java 17+.
+jakarta-authentication-issue-138-case-3=Jakarta Authentication 3.1 Issue # 138 \
+\n The method jakarta.security.auth.message.config.AuthConfigFactory.providerRegistrationSecurityPermission(String, String) was removed. \
+\n This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1 \
+\n due to the removal of SecurityManager support in Java 17+.

--- a/src/main/resources/config/jakarta11/mappedPatterns/jakarta-authentication.properties
+++ b/src/main/resources/config/jakarta11/mappedPatterns/jakarta-authentication.properties
@@ -1,0 +1,42 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+# Jakarta Authentication 3.1 - Removal of SecurityManager references (Issue #138)
+jakarta-authentication-method-issue-138-case-1-error=jakarta.security.auth.message.config.AuthConfigFactory#getFactorySecurityPermission
+jakarta-authentication-method-issue-138-case-2-error=jakarta.security.auth.message.config.AuthConfigFactory#setFactorySecurityPermission
+jakarta-authentication-method-issue-138-case-3-error=jakarta.security.auth.message.config.AuthConfigFactory#providerRegistrationSecurityPermission


### PR DESCRIPTION
  ---
  Adding mapping for Jakarta Authentication 3.1 changes - SecurityManager removal

  Testing:
  Use the following reproducer: [AdvisorReproducerExamples](https://github.com/breakponchito/AdvisorReproducerExamples.gi)t

  On the root folder of the application execute the following command:

  `mvn fish.payara.advisor:advisor-maven-plugin:2.0-SNAPSHOT:advise -DadviseVersion=11`

  Changes:

  For Jakarta Authentication 3.1, we need to indicate that three SecurityManager-related methods were removed from AuthConfigFactory as part of Issue #138. These methods were deprecated in Jakarta Authentication 3.0 and
   completely removed in 3.1 due to the removal of SecurityManager support in Java 17+:

  - getFactorySecurityPermission() - Previously used to retrieve the security permission
  - setFactorySecurityPermission(Permission) - Previously used to set the security permission
  - providerRegistrationSecurityPermission(String, String) - Previously used for provider registration security checks

  The tool now detects usage of these removed methods and advises developers to:
  1. Remove all calls to these methods
  2. Use alternative security mechanisms provided by Jakarta Security or the application server
  3. Update their code as SecurityManager-based security checks are no longer supported in Jakarta EE 11

  Example detection results:

```
[ERROR] Line of code: 73 | Expression: getFactorySecurityPermission()
  Source file: AuthConfigFactoryExample.java
  Jakarta Authentication 3.1 Issue # 138
   The method jakarta.security.auth.message.config.AuthConfigFactory.getFactorySecurityPermission() was removed.

   This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1

   due to the removal of SecurityManager support in Java 17+.

  Your application won't work.
   Please remove all calls to AuthConfigFactory.getFactorySecurityPermission().

   SecurityManager-based security checks are no longer supported in Jakarta EE 11.

   Consider using alternative security mechanisms provided by Jakarta Security or your application server.

  [ERROR] Line of code: 81 | Expression: providerRegistrationSecurityPermission("HTTP", "myApp")
  Source file: AuthConfigFactoryExample.java
  Jakarta Authentication 3.1 Issue # 138
   The method jakarta.security.auth.message.config.AuthConfigFactory.providerRegistrationSecurityPermission(String, String) was removed.

   This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1

   due to the removal of SecurityManager support in Java 17+.

  Your application won't work.
   Please remove all calls to AuthConfigFactory.providerRegistrationSecurityPermission(String, String).

   SecurityManager-based security checks are no longer supported in Jakarta EE 11.

   Consider using alternative security mechanisms provided by Jakarta Security or your application server.

  [ERROR] Line of code: 77 | Expression: setFactorySecurityPermission(new RuntimePermission("test"))
  Source file: AuthConfigFactoryExample.java
  Jakarta Authentication 3.1 Issue # 138
   The method jakarta.security.auth.message.config.AuthConfigFactory.setFactorySecurityPermission(Permission) was removed.

   This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1

   due to the removal of SecurityManager support in Java 17+.

  Your application won't work.
   Please remove all calls to AuthConfigFactory.setFactorySecurityPermission(Permission).

   SecurityManager-based security checks are no longer supported in Jakarta EE 11.

   Consider using alternative security mechanisms provided by Jakarta Security or your application server.

  [ERROR] Line of code: 33 | Expression: getFactorySecurityPermission()
  Source file: CustomAuthConfigFactory.java
  Jakarta Authentication 3.1 Issue # 138
   The method jakarta.security.auth.message.config.AuthConfigFactory.getFactorySecurityPermission() was removed.

   This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1

   due to the removal of SecurityManager support in Java 17+.

  Your application won't work.
   Please remove all calls to AuthConfigFactory.getFactorySecurityPermission().

   SecurityManager-based security checks are no longer supported in Jakarta EE 11.

   Consider using alternative security mechanisms provided by Jakarta Security or your application server.

  [ERROR] Line of code: 49 | Expression: providerRegistrationSecurityPermission(layer, appContext)
  Source file: CustomAuthConfigFactory.java
  Jakarta Authentication 3.1 Issue # 138
   The method jakarta.security.auth.message.config.AuthConfigFactory.providerRegistrationSecurityPermission(String, String) was removed.

   This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1

   due to the removal of SecurityManager support in Java 17+.

  Your application won't work.
   Please remove all calls to AuthConfigFactory.providerRegistrationSecurityPermission(String, String).

   SecurityManager-based security checks are no longer supported in Jakarta EE 11.

   Consider using alternative security mechanisms provided by Jakarta Security or your application server.

  [ERROR] Line of code: 37 | Expression: setFactorySecurityPermission(new RuntimePermission("getAuthConfigFactory"))
  Source file: CustomAuthConfigFactory.java
  Jakarta Authentication 3.1 Issue # 138
   The method jakarta.security.auth.message.config.AuthConfigFactory.setFactorySecurityPermission(Permission) was removed.

   This method was deprecated in Jakarta Authentication 3.0 and has been completely removed in 3.1

   due to the removal of SecurityManager support in Java 17+.

  Your application won't work.
   Please remove all calls to AuthConfigFactory.setFactorySecurityPermission(Permission).

   SecurityManager-based security checks are no longer supported in Jakarta EE 11.

   Consider using alternative security mechanisms provided by Jakarta Security or your application server.
```

  The tool successfully identifies all three removed methods across AuthConfigFactoryExample.java and CustomAuthConfigFactory.java, providing clear migration guidance for each case.