### PR TITLE
Fish 12567 fixing annotation mapping for microprofile

### DIFF
--- a/src/it/test-ee11/advisor-baseline.txt
+++ b/src/it/test-ee11/advisor-baseline.txt
@@ -118,31 +118,31 @@ Jakarta Authorization 3.0
  Since Jakarta Authorization 3.0 all references for Security Manager were removed.
 Your application won't work,
  please remove System#getSecurityManager method because it will not compile in Jakarta EE 11.
-[WARNING] Line of code: 50 | Expression: java.util.Calendar
-Source file: LegacyBean.java
-Jakarta Persistence 3.2
- since Jakarta Persistence 3.2 this type was marked for deprecation.
-This issue won't affect your application.
- But it is recommended to substitute with java.time API. In future releases for Jakarta,
- maintaining deprecated types will cause issues on your application.
-[WARNING] Line of code: 46 | Expression: jakarta.persistence.TemporalType
-Source file: LegacyBean.java
-Jakarta Persistence 3.2
- since Jakarta Persistence 3.2 this type was marked for deprecation.
-This issue won't affect your application.
- But it is recommended to substitute with java.time API. In future releases for Jakarta,
- maintaining deprecated types will cause issues on your application.
-[ERROR] Line of code: 42 | Expression: jakarta.annotation.ManagedBean
-Source file: LegacyBean.java
-Jakarta Annotations 3.0 issue 114
- Since 3.0 the annotation jakarta.annotation.ManagedBean was removed.
-Your application won't work,
- please remove annotation jakarta.annotation.ManagedBean and replace with
- CDI scopes and naming.
-[WARNING] Line of code: 45 | Expression: jakarta.persistence.Temporal
-Source file: LegacyBean.java
-Jakarta Persistence 3.2
- since Jakarta Persistence 3.2 this type was marked for deprecation.
-This issue won't affect your application.
- But it is recommended to substitute with java.time API. In future releases for Jakarta,
- maintaining deprecated types will cause issues on your application.
+ [WARNING] Line of code: 46 | Expression: jakarta.persistence.TemporalType                                                                                      
+Source file: LegacyBean.java                                                                                                                                   
+Jakarta Persistence 3.2                                                                                                                                        
+since Jakarta Persistence 3.2 this type was marked for deprecation.                                                                                            
+This issue won't affect your application.                                                                                                                      
+But it is recommended to substitute with java.time API. In future releases for Jakarta,                                                                        
+maintaining deprecated types will cause issues on your application.                                                                                            
+[ERROR] Line of code: 42 | Expression: jakarta.annotation.ManagedBean                                                                                          
+Source file: LegacyBean.java                                                                                                                                   
+Jakarta Annotations 3.0 issue 114                                                                                                                              
+Since 3.0 the annotation jakarta.annotation.ManagedBean was removed.                                                                                           
+Your application won't work,                                                                                                                                   
+please remove annotation jakarta.annotation.ManagedBean and replace with                                                                                       
+CDI scopes and naming.                                                                                                                                         
+[WARNING] Line of code: 45 | Expression: jakarta.persistence.Temporal                                                                                          
+Source file: LegacyBean.java                                                                                                                                   
+Jakarta Persistence 3.2                                                                                                                                        
+since Jakarta Persistence 3.2 this type was marked for deprecation.                                                                                            
+This issue won't affect your application.                                                                                                                      
+But it is recommended to substitute with java.time API. In future releases for Jakarta,                                                                        
+maintaining deprecated types will cause issues on your application.                                                                                            
+[WARNING] Line of code: 50 | Expression: java.util.Calendar                                                                                                    
+Source file: LegacyBean.java                                                                                                                                   
+Jakarta Persistence 3.2                                                                                                                                        
+since Jakarta Persistence 3.2 this type was marked for deprecation.                                                                                            
+This issue won't affect your application.                                                                                                                      
+But it is recommended to substitute with java.time API. In future releases for Jakarta,                                                                        
+maintaining deprecated types will cause issues on your application. 

--- a/src/it/test-mp6/advisor-baseline.txt
+++ b/src/it/test-mp6/advisor-baseline.txt
@@ -2,11 +2,21 @@
 [INFO] ***************
 [ERROR] Line of code: 67 | Expression: org.eclipse.microprofile.metrics.annotation.Metered
 Source file: Mp4LegacyResource.java
-Microprofile Metrics 5.0
- org.eclipse.microprofile.metrics.annotation.Metered annotation was REMOVED;
+Microprofile Metrics 5.0 
+ org.eclipse.microprofile.metrics.annotation.Metered annotation was REMOVED;                                                                                         
 Your application won't work, please remove Metered annotation because it will not compile in Microprofile 6.
 [ERROR] Line of code: 53 | Expression: org.eclipse.microprofile.opentracing.Traced
 Source file: Mp4LegacyResource.java
-Microprofile OpenTracing was replaced by OpenTelemetry
- annotation @Traced cannot be used;
+Microprofile OpenTracing was replaced by OpenTelemetry 
+ annotation @Traced cannot be used;                                                                                                                                  
+Your application won't work, please replace annotation @Traced with @WithSpan;
+[ERROR] Line of code: 116 | Expression: @Metered(name = "legacy_meter", description = "Metered metric example")
+Source file: Mp4LegacyResource.java
+Microprofile Metrics 5.0 
+ org.eclipse.microprofile.metrics.annotation.Metered annotation was REMOVED;                                                                                         
+Your application won't work, please remove Metered annotation because it will not compile in Microprofile 6.
+[ERROR] Line of code: 140 | Expression: @Traced(operationName = "legacyTracingOperation")
+Source file: Mp4LegacyResource.java
+Microprofile OpenTracing was replaced by OpenTelemetry 
+ annotation @Traced cannot be used;                                                                                                                                  
 Your application won't work, please replace annotation @Traced with @WithSpan;

--- a/src/main/java/fish/payara/advisor/AdvisorAnnotationWithProperty.java
+++ b/src/main/java/fish/payara/advisor/AdvisorAnnotationWithProperty.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -108,7 +108,8 @@ public class AdvisorAnnotationWithProperty implements AdvisorInterface {
             super.visit(markerAnnotationExpr, collector);
             Optional<Position> p = markerAnnotationExpr.getBegin();
             String annotationName = valuePattern.substring(valuePattern.lastIndexOf(".") + 1, valuePattern.length());
-            if (markerAnnotationExpr.toString().contains(annotationName) && markerAnnotationExpr.toString().contains(secondPattern)) {
+            String annotationValue = markerAnnotationExpr.toString().substring(1);
+            if (annotationValue.equals(annotationName) && markerAnnotationExpr.toString().contains(secondPattern)) {
                 AdvisorBean advisorBean = new AdvisorBean.AdvisorBeanBuilder(keyPattern, annotationName + "@" + secondPattern)
                         .setLine((p.map(position -> "" + position.line).orElse("")))
                         .setAnnotationDeclaration(markerAnnotationExpr.toString()).build();

--- a/src/main/java/fish/payara/advisor/AdvisorClassImport.java
+++ b/src/main/java/fish/payara/advisor/AdvisorClassImport.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -44,6 +44,7 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -72,7 +73,7 @@ public class AdvisorClassImport implements AdvisorInterface {
         public void visit(final ImportDeclaration importDeclaration, final List<AdvisorBean> collector) {
             super.visit(importDeclaration, collector);
             Optional<Position> p = importDeclaration.getBegin();
-            if (normalizeImportDeclaration(importDeclaration).endsWith(valuePattern)) {
+            if (normalizeImportDeclarationAndValidate(importDeclaration, valuePattern)) {
                 AdvisorBean advisorBean = new AdvisorBean.AdvisorBeanBuilder(keyPattern, valuePattern)
                         .setLine((p.map(position -> "" + position.line).orElse("")))
                                 .setImportDeclaration(importDeclaration.getNameAsString()).build();
@@ -81,7 +82,7 @@ public class AdvisorClassImport implements AdvisorInterface {
         }
     }
 
-    private static String normalizeImportDeclaration(ImportDeclaration importDeclaration) {
-        return importDeclaration.toString().split(";")[0];
+    private static boolean normalizeImportDeclarationAndValidate(ImportDeclaration importDeclaration, String valuePattern) {
+        return Arrays.stream(importDeclaration.toString().split(";")).anyMatch(s -> s.endsWith(valuePattern));
     }
 }

--- a/src/main/java/fish/payara/advisor/AdvisorEvaluator.java
+++ b/src/main/java/fish/payara/advisor/AdvisorEvaluator.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -153,18 +153,13 @@ public class AdvisorEvaluator {
         String annotationPropertyDeclaration = value.substring(value.indexOf("@") + 1, value.length());
         //search import
         AdvisorBean advisorBean = null;
-        AdvisorClassImport acimp = new AdvisorClassImport();
         try {
-            advisorBean = acimp.parseFile(key, importAnnotationNameSpace, sourceFile);
-            //check if annotation with property
-            if (advisorBean != null) {
-                AdvisorAnnotationWithProperty aacwp = new AdvisorAnnotationWithProperty();
-                advisorBean = aacwp.parseFile(key, importAnnotationNameSpace, annotationPropertyDeclaration, sourceFile);
-                if(advisorBean != null && !advisorsList.contains(advisorBean)) {
-                    advisorsList.add(advisorBean);
-                }
+            AdvisorAnnotationWithProperty aacwp = new AdvisorAnnotationWithProperty();
+            advisorBean = aacwp.parseFile(key, importAnnotationNameSpace, annotationPropertyDeclaration, sourceFile);
+            if (advisorBean != null && !advisorsList.contains(advisorBean)) {
+                advisorsList.add(advisorBean);
             }
-        } catch(FileNotFoundException e) {
+        } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/fish/payara/advisor/AdvisorInterface.java
+++ b/src/main/java/fish/payara/advisor/AdvisorInterface.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -58,11 +58,38 @@ public interface AdvisorInterface {
         VoidVisitor<List<AdvisorBean>> collector = createVoidVisitor(keyPattern, valuePattern, params);
         CompilationUnit compilationUnit = StaticJavaParser.parse(f);
         collector.visit(compilationUnit, advisorBeanList);
-        if (advisorBeanList.size() > 0) {
+        if (!advisorBeanList.isEmpty()) {
             AdvisorBean b = advisorBeanList.get(0);
-            b.setFile(f);
-            return b;
+            String importDeclaration = b.getImportDeclaration();
+            if (importDeclaration != null && (valuePattern.contains("jakarta") || valuePattern.contains("javax"))) {
+                return compareImports(importDeclaration, valuePattern, b, f);
+            } else if (importDeclaration != null) {
+                importDeclaration = removingPrefixFromNameSpace(importDeclaration);
+                return compareImports(importDeclaration, valuePattern, b, f);
+            } else if (importDeclaration == null) {
+                b.setFile(f);
+                return b;
+            }
         }
         return null;
+    }
+
+    private String removingPrefixFromNameSpace(String importDeclaration) {
+        if (importDeclaration.contains("javax")) {
+            int position = importDeclaration.indexOf("javax");
+            return importDeclaration.substring(position + 6);
+        } else if (importDeclaration.contains("jakarta")) {
+            int position = importDeclaration.indexOf("jakarta");
+            return importDeclaration.substring(position + 8);
+        }
+        return importDeclaration;
+    }
+
+    private AdvisorBean compareImports(String importDeclaration, String valuePattern, AdvisorBean b, File f) {
+        if (this instanceof AdvisorClassImport && !importDeclaration.equals(valuePattern)) {
+            return null;
+        }
+        b.setFile(f);
+        return b;
     }
 }

--- a/src/main/resources/microprofile/v6/advisorFix/microprofile-metrics-fix-messages.properties
+++ b/src/main/resources/microprofile/v6/advisorFix/microprofile-metrics-fix-messages.properties
@@ -1,6 +1,6 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
@@ -38,14 +38,20 @@
 #
 microprofile-metrics-remove-simple-timer=Your application won't work, \
   please remove SimpleTimer interface because it will not compile in Microprofile 6.
+microprofile-metrics-remove-import-simply-timed=Your application won't work, \
+  please remove SimplyTimed annotation because it will not compile in Microprofile 6.
 microprofile-metrics-remove-annotation-simply-timed=Your application won't work, \
   please remove SimplyTimed annotation because it will not compile in Microprofile 6.
 microprofile-metrics-remove-concurrent-gauge=Your application won't work, \
   please remove ConcurrentGauge interface because it will not compile in Microprofile 6.
+microprofile-metrics-remove-import-concurrent-gauge=Your application won't work, \
+  please remove ConcurrentGauge annotation because it will not compile in Microprofile 6.
 microprofile-metrics-remove-annotation-concurrent-gauge=Your application won't work, \
   please remove ConcurrentGauge annotation because it will not compile in Microprofile 6.
 microprofile-metrics-remove-meter=Your application won't work, \
   please remove Meter interface because it will not compile in Microprofile 6.
+microprofile-metrics-remove-import-metered=Your application won't work, \
+  please remove Metered annotation because it will not compile in Microprofile 6.
 microprofile-metrics-remove-annotation-metered=Your application won't work, \
   please remove Metered annotation because it will not compile in Microprofile 6.
 microprofile-metrics-remove-metered=Your application won't work, \
@@ -168,6 +174,8 @@ microprofile-metrics-remove-metric-type-metered=Your application won't work, \
   please remove MetricType.METERED enum reference because it will not compile in Microprofile 6.
 microprofile-metrics-remove-metric-type-simple-timer=Your application won't work, \
   please remove MetricType.SIMPLE_TIMER enum reference because it will not compile in Microprofile 6.
+microprofile-metrics-remove-import-deprecated=This issue won't affect your application. \n \
+  The advice is to stop using the annotation RegistryType and use RegistryScope instead.
 microprofile-metrics-remove-annotation-deprecated=This issue won't affect your application. \n \
   The advice is to stop using the annotation RegistryType and use RegistryScope instead.
 microprofile-metrics-remove-enum-deprecated=This issue won't affect your application. \n \

--- a/src/main/resources/microprofile/v6/advisorFix/microprofile-telemetry-fix-messages.properties
+++ b/src/main/resources/microprofile/v6/advisorFix/microprofile-telemetry-fix-messages.properties
@@ -1,6 +1,6 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
@@ -38,6 +38,8 @@
 #
 microprofile-telemetry-remove-traced=Your application won't work, \
   please replace io.opentracing.Tracer with io.opentelemetry.api.trace.Tracer;
+microprofile-telemetry-remove-import-traced=Your application won't work, \
+  please replace annotation @Traced with @WithSpan;
 microprofile-telemetry-remove-annotation-traced=Your application won't work, \
   please replace annotation @Traced with @WithSpan;
 microprofile-telemetry-remove-scope=Your application won't work, \

--- a/src/main/resources/microprofile/v6/advisorMessages/microprofile-metrics-messages.properties
+++ b/src/main/resources/microprofile/v6/advisorMessages/microprofile-metrics-messages.properties
@@ -1,6 +1,6 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
@@ -38,14 +38,20 @@
 #
 microprofile-metrics-remove-simple-timer=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.SimpleTimer interface was REMOVED;
+microprofile-metrics-remove-import-simply-timed=Microprofile Metrics 5.0 \
+\n org.eclipse.microprofile.metrics.annotation.SimplyTimed annotation was REMOVED;
 microprofile-metrics-remove-annotation-simply-timed=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.annotation.SimplyTimed annotation was REMOVED;
 microprofile-metrics-remove-concurrent-gauge=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.ConcurrentGauge interface was REMOVED;
+microprofile-metrics-remove-import-concurrent-gauge=Microprofile Metrics 5.0 \
+\n org.eclipse.microprofile.metrics.annotation.ConcurrentGauge annotation was REMOVED;
 microprofile-metrics-remove-annotation-concurrent-gauge=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.annotation.ConcurrentGauge annotation was REMOVED;
 microprofile-metrics-remove-meter=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.Meter interface was REMOVED;
+microprofile-metrics-remove-import-metered=Microprofile Metrics 5.0 \
+\n org.eclipse.microprofile.metrics.annotation.Metered annotation was REMOVED;
 microprofile-metrics-remove-annotation-metered=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.annotation.Metered annotation was REMOVED;
 microprofile-metrics-remove-metered=Microprofile Metrics 5.0 \
@@ -168,6 +174,8 @@ microprofile-metrics-remove-metric-type-metered=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.MetricType.METERED enum was REMOVED;
 microprofile-metrics-remove-metric-type-simple-timer=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.MetricType.SIMPLE_TIMER enum was REMOVED;
+microprofile-metrics-remove-import-deprecated=Microprofile Metrics 5.0 \
+\n org.eclipse.microprofile.metrics.annotation.RegistryType annotation was DEPRECATED and future version of Microprofile Metrics will no longer support it;
 microprofile-metrics-remove-annotation-deprecated=Microprofile Metrics 5.0 \
 \n org.eclipse.microprofile.metrics.annotation.RegistryType annotation was DEPRECATED and future version of Microprofile Metrics will no longer support it;
 microprofile-metrics-remove-enum-deprecated=Microprofile Metrics 5.0 \

--- a/src/main/resources/microprofile/v6/advisorMessages/microprofile-telemetry-messages.properties
+++ b/src/main/resources/microprofile/v6/advisorMessages/microprofile-telemetry-messages.properties
@@ -1,6 +1,6 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
@@ -38,6 +38,8 @@
 #
 microprofile-telemetry-remove-traced=Microprofile OpenTracing was replaced by OpenTelemetry \
 \n io.opentracing.Tracer cannot be used;
+microprofile-telemetry-remove-import-traced=Microprofile OpenTracing was replaced by OpenTelemetry \
+\n annotation @Traced cannot be used;
 microprofile-telemetry-remove-annotation-traced=Microprofile OpenTracing was replaced by OpenTelemetry \
 \n annotation @Traced cannot be used;
 microprofile-telemetry-remove-scope=Microprofile OpenTracing was replaced by OpenTelemetry \

--- a/src/main/resources/microprofile/v6/mappedPatterns/microprofile-metrics.properties
+++ b/src/main/resources/microprofile/v6/mappedPatterns/microprofile-metrics.properties
@@ -1,6 +1,6 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
@@ -37,11 +37,14 @@
 # holder.
 #
 microprofile-metrics-remove-simple-timer-error=org.eclipse.microprofile.metrics.SimpleTimer
-microprofile-metrics-remove-annotation-simply-timed-error=org.eclipse.microprofile.metrics.annotation.SimplyTimed
+microprofile-metrics-remove-import-simply-timed-error=org.eclipse.microprofile.metrics.annotation.SimplyTimed
+microprofile-metrics-remove-annotation-simply-timed-error=org.eclipse.microprofile.metrics.annotation.SimplyTimed@name
 microprofile-metrics-remove-concurrent-gauge-error=org.eclipse.microprofile.metrics.ConcurrentGauge
-microprofile-metrics-remove-annotation-concurrent-gauge-error=org.eclipse.microprofile.metrics.annotation.ConcurrentGauge
+microprofile-metrics-remove-import-concurrent-gauge-error=org.eclipse.microprofile.metrics.annotation.ConcurrentGauge
+microprofile-metrics-remove-annotation-concurrent-gauge-error=org.eclipse.microprofile.metrics.annotation.ConcurrentGauge@name
 microprofile-metrics-remove-meter-error=org.eclipse.microprofile.metrics.Meter
-microprofile-metrics-remove-annotation-metered-error=org.eclipse.microprofile.metrics.annotation.Metered
+microprofile-metrics-remove-import-metered-error=org.eclipse.microprofile.metrics.annotation.Metered
+microprofile-metrics-remove-annotation-metered-error=org.eclipse.microprofile.metrics.annotation.Metered@name
 microprofile-metrics-remove-metered-error=org.eclipse.microprofile.metrics.Metered
 microprofile-metrics-remove-metrics-type-error=org.eclipse.microprofile.metrics.MetricType
 microprofile-metrics-method-removed-get-fifteen-minute-rate-error=org.eclipse.microprofile.metrics.Timer#getFifteenMinuteRate
@@ -102,5 +105,6 @@ microprofile-metrics-interface-change-type-extends-number-warn=org.eclipse.micro
 microprofile-metrics-remove-metric-type-concurrent-gauge-error=org.eclipse.microprofile.metrics.MetricType.CONCURRENT_GAUGE
 microprofile-metrics-remove-metric-type-metered-error=org.eclipse.microprofile.metrics.MetricType.METERED
 microprofile-metrics-remove-metric-type-simple-timer-error=org.eclipse.microprofile.metrics.MetricType.SIMPLE_TIMER
-microprofile-metrics-remove-annotation-deprecated-warn=org.eclipse.microprofile.metrics.annotation.RegistryType
+microprofile-metrics-remove-import-deprecated-warn=org.eclipse.microprofile.metrics.annotation.RegistryType
+microprofile-metrics-remove-annotation-deprecated-warn=org.eclipse.microprofile.metrics.annotation.RegistryType@type
 microprofile-metrics-remove-enum-deprecated-warn=org.eclipse.microprofile.metrics.MetricRegistry.Type

--- a/src/main/resources/microprofile/v6/mappedPatterns/microprofile-telemetry.properties
+++ b/src/main/resources/microprofile/v6/mappedPatterns/microprofile-telemetry.properties
@@ -1,6 +1,6 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
@@ -37,7 +37,8 @@
 # holder.
 #
 microprofile-telemetry-remove-traced-error=io.opentracing.Tracer
-microprofile-telemetry-remove-annotation-traced-error=org.eclipse.microprofile.opentracing.Traced
+microprofile-telemetry-remove-import-traced-error=org.eclipse.microprofile.opentracing.Traced
+microprofile-telemetry-remove-annotation-traced-error=org.eclipse.microprofile.opentracing.Traced@operationName
 microprofile-telemetry-remove-scope-error=io.opentracing.Scope
 microprofile-telemetry-remove-span-error=io.opentracing.Span
 microprofile-telemetry-remove-tags-error=io.opentracing.tag.Tags


### PR DESCRIPTION
I fixed the reported issue to map annotations and imports for microprofile. Now if you include import and annotation mapping you will see both advices and if you commented any of those from the code automatically the case will disappier and the message for the advise should advise the correct import